### PR TITLE
SPEC 05: performance and test suite

### DIFF
--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eda7971037ed5c34192c5e8f0e2fd963
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode.meta
+++ b/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e8cb51f351eabd40a7e1873b6b495cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/CityGenerator.Tests.EditMode.asmdef
+++ b/Assets/Tests/EditMode/CityGenerator.Tests.EditMode.asmdef
@@ -1,0 +1,26 @@
+{
+    "name": "CityGenerator.Tests.EditMode",
+    "rootNamespace": "CityGenerator.Tests.EditMode",
+    "references": [
+        "CityGenerator.Runtime",
+        "CityGenerator.Editor",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Unity.InputSystem"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/EditMode/CityGenerator.Tests.EditMode.asmdef.meta
+++ b/Assets/Tests/EditMode/CityGenerator.Tests.EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 969ffac528772a24d972a64e04185f09
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/CityGeneratorDistributionUtilityTests.cs
+++ b/Assets/Tests/EditMode/CityGeneratorDistributionUtilityTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using CityGenerator.Editor;
+using NUnit.Framework;
+
+namespace CityGenerator.Tests.EditMode
+{
+    internal class CityGeneratorDistributionUtilityTests
+    {
+        private readonly struct Entry
+        {
+            public readonly float percentage;
+            public Entry(float percentage) => this.percentage = percentage;
+        }
+
+        [Test]
+        public void DistributePercentages_ExactDivision_MatchesFloorShares()
+        {
+            var entries = new List<Entry> { new(50f), new(30f), new(20f) };
+            int[] counts = CityGeneratorDistributionUtility.DistributePercentages(entries, 10, e => e.percentage);
+
+            CollectionAssert.AreEqual(new[] { 5, 3, 2 }, counts);
+        }
+
+        [Test]
+        public void DistributePercentages_TotalAlwaysMatchesRequestedCount()
+        {
+            var entries = new List<Entry> { new(33.34f), new(33.33f), new(33.33f) };
+            int[] counts = CityGeneratorDistributionUtility.DistributePercentages(entries, 10, e => e.percentage);
+
+            int sum = 0;
+            foreach (int c in counts) sum += c;
+            Assert.AreEqual(10, sum);
+        }
+
+        [Test]
+        public void DistributePercentages_LeftoverGoesToLargestRemainderFirst()
+        {
+            // Exact shares: 3.334, 3.333, 3.333 -> floors 3,3,3 (assigned 9), 1 leftover.
+            // Entry 0 has the largest fractional remainder, so it gets the extra unit.
+            var entries = new List<Entry> { new(33.34f), new(33.33f), new(33.33f) };
+            int[] counts = CityGeneratorDistributionUtility.DistributePercentages(entries, 10, e => e.percentage);
+
+            Assert.AreEqual(4, counts[0]);
+            Assert.AreEqual(3, counts[1]);
+            Assert.AreEqual(3, counts[2]);
+        }
+
+        [Test]
+        public void DistributePercentages_ZeroTotalCount_ReturnsAllZeros()
+        {
+            var entries = new List<Entry> { new(50f), new(50f) };
+            int[] counts = CityGeneratorDistributionUtility.DistributePercentages(entries, 0, e => e.percentage);
+
+            CollectionAssert.AreEqual(new[] { 0, 0 }, counts);
+        }
+
+        [Test]
+        public void DistributePercentages_SingleEntryAt100Percent_GetsEverything()
+        {
+            var entries = new List<Entry> { new(100f) };
+            int[] counts = CityGeneratorDistributionUtility.DistributePercentages(entries, 37, e => e.percentage);
+
+            CollectionAssert.AreEqual(new[] { 37 }, counts);
+        }
+
+        [Test]
+        public void DistributePercentages_EmptyEntriesAndZeroTotal_ReturnsEmptyArray()
+        {
+            var entries = new List<Entry>();
+            int[] counts = CityGeneratorDistributionUtility.DistributePercentages(entries, 0, e => e.percentage);
+
+            Assert.AreEqual(0, counts.Length);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/CityGeneratorDistributionUtilityTests.cs.meta
+++ b/Assets/Tests/EditMode/CityGeneratorDistributionUtilityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca41e6e570e73f945ae6c90eb25a140e

--- a/Assets/Tests/EditMode/CityGeneratorGridTests.cs
+++ b/Assets/Tests/EditMode/CityGeneratorGridTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using CityGenerator.Editor;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CityGenerator.Tests.EditMode
+{
+    internal class CityGeneratorGridTests
+    {
+        [Test]
+        public void BuildBlocks_ReturnsOneCellPerGridPosition()
+        {
+            List<BlockCell> cells = CityGeneratorGrid.BuildBlocks(3, 2, new List<Vector2Int>());
+
+            Assert.AreEqual(6, cells.Count);
+            for (int gx = 0; gx < 3; gx++)
+            {
+                for (int gy = 0; gy < 2; gy++)
+                {
+                    Assert.IsTrue(cells.Exists(c => c.gridX == gx && c.gridY == gy),
+                        $"Missing cell ({gx},{gy})");
+                }
+            }
+        }
+
+        [Test]
+        public void BuildBlocks_MarksOnlyConfiguredCellsAsPlazas()
+        {
+            var plazaCells = new List<Vector2Int> { new(1, 1), new(2, 0) };
+            List<BlockCell> cells = CityGeneratorGrid.BuildBlocks(3, 3, plazaCells);
+
+            foreach (BlockCell cell in cells)
+            {
+                bool shouldBePlaza = plazaCells.Contains(new Vector2Int(cell.gridX, cell.gridY));
+                Assert.AreEqual(shouldBePlaza, cell.isPlaza, $"Cell ({cell.gridX},{cell.gridY})");
+            }
+        }
+
+        [Test]
+        public void BuildBlocks_WithNoPlazaCells_MarksNoBlockAsPlaza()
+        {
+            List<BlockCell> cells = CityGeneratorGrid.BuildBlocks(2, 2, new List<Vector2Int>());
+            Assert.IsFalse(cells.Exists(c => c.isPlaza));
+        }
+
+        [Test]
+        public void GetBlockCenter_IsSymmetricAroundOrigin()
+        {
+            // A 4-wide grid has no exact centre column, but opposite blocks must mirror around 0.
+            Vector3 left = CityGeneratorGrid.GetBlockCenter(0, 0, 4, 4);
+            Vector3 right = CityGeneratorGrid.GetBlockCenter(3, 0, 4, 4);
+
+            Assert.AreEqual(-right.x, left.x, 0.0001f);
+        }
+
+        [Test]
+        public void GetBlockAxisPosition_AdjacentBlocksAreOneCellPitchApart()
+        {
+            float a = CityGeneratorGrid.GetBlockAxisPosition(5, 2);
+            float b = CityGeneratorGrid.GetBlockAxisPosition(5, 3);
+
+            Assert.AreEqual(CityGeneratorConstants.CellPitch, b - a, 0.0001f);
+        }
+
+        [Test]
+        public void GetStreetAxisPosition_HasOneMoreAxisThanBlocks()
+        {
+            // A 3-block grid has 4 street axes (0..3): the first and last bound the grid.
+            float first = CityGeneratorGrid.GetStreetAxisPosition(3, 0);
+            float last = CityGeneratorGrid.GetStreetAxisPosition(3, 3);
+
+            Assert.AreEqual(-last, first, 0.0001f);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/CityGeneratorGridTests.cs.meta
+++ b/Assets/Tests/EditMode/CityGeneratorGridTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d3be5e348de811f41b294558e2858333

--- a/Assets/Tests/EditMode/CityGeneratorValidatorTests.cs
+++ b/Assets/Tests/EditMode/CityGeneratorValidatorTests.cs
@@ -1,0 +1,358 @@
+using System.Collections.Generic;
+using CityGenerator.Editor;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CityGenerator.Tests.EditMode
+{
+    internal class CityGeneratorValidatorTests
+    {
+        private readonly List<GameObject> spawned = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (GameObject go in spawned)
+            {
+                if (go != null)
+                    Object.DestroyImmediate(go);
+            }
+            spawned.Clear();
+        }
+
+        private GameObject MakePrefabLike(string name)
+        {
+            var go = new GameObject(name);
+            go.AddComponent<MeshRenderer>();
+            spawned.Add(go);
+            return go;
+        }
+
+        private GameObject MakePrefabLikeNoRenderer(string name)
+        {
+            var go = new GameObject(name);
+            spawned.Add(go);
+            return go;
+        }
+
+        private CityGeneratorSettings MakeMinimalValidSettings()
+        {
+            var settings = new CityGeneratorSettings();
+            settings.general.gridWidth = 1;
+            settings.general.gridHeight = 1; // no interior intersections: no traffic light required
+            settings.general.includeTraffic = false;
+            settings.general.includePedestrians = false;
+            settings.ground.roadBasePrefab = MakePrefabLike("RoadBase");
+            settings.ground.sidewalkPrefab = MakePrefabLike("Sidewalk");
+            settings.ground.roadLinePrefab = MakePrefabLike("RoadLine");
+            settings.ground.crosswalkLinePrefab = MakePrefabLike("Crosswalk");
+            settings.vegetation.density = 0f; // avoid the unrelated "no prefabs" issue in tests not about vegetation
+            return settings;
+        }
+
+        [Test]
+        public void ValidateDetailed_MinimalValidSettings_HasNoBlockingIssues()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsTrue(valid, string.Join("; ", issues.ConvertAll(i => i.message)));
+        }
+
+        [Test]
+        public void ValidateDetailed_MissingRoadBasePrefab_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.ground.roadBasePrefab = null;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "ground.roadBasePrefab" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_PlazaCellsWithoutLawnPrefab_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.general.plazaCells.Add(new Vector2Int(0, 0));
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "plaza.lawnPrefab" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_PlayerPrefabWithoutInputActions_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.general.playerPrefab = MakePrefabLike("Player");
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "general.inputActions" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_EmptyBuildingPrefabEntry_IsWarningOnly()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.buildingPrefabs.Add(null);
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsTrue(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "buildingPrefabs" && i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_BuildingPrefabWithoutRenderer_IsWarningOnly()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.buildingPrefabs.Add(MakePrefabLikeNoRenderer("NoRenderer"));
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsTrue(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "buildingPrefabs" && i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_InteriorIntersectionWithoutTrafficLightPrefab_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.general.gridWidth = 2;
+            settings.general.gridHeight = 2; // at least one interior intersection
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "props.trafficLightPrefab" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_TrafficLightPrefabWithoutComponent_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.general.gridWidth = 2;
+            settings.general.gridHeight = 2;
+            settings.props.trafficLightPrefab = MakePrefabLike("TrafficLightNoComponent");
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "props.trafficLightPrefab" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_TrafficLightPrefabWithComponent_ClearsInteriorIntersectionIssue()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.general.gridWidth = 2;
+            settings.general.gridHeight = 2;
+            GameObject light = MakePrefabLike("TrafficLight");
+            light.AddComponent<CityGenerator.Runtime.TrafficLight>();
+            settings.props.trafficLightPrefab = light;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsTrue(valid, string.Join("; ", issues.ConvertAll(i => i.message)));
+        }
+
+        [Test]
+        public void ValidateDetailed_VegetationDensityWithoutPrefabs_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.vegetation.density = 0.5f;
+            settings.vegetation.prefabs.Clear();
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "vegetation.prefabs" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_VehiclesRequiredWhenTrafficAndCountPositive()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.general.includeTraffic = true;
+            settings.general.vehicleCount = 10;
+            settings.vehicles.Clear();
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "vehicles" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_VehiclePercentagesMustSumTo100()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.general.includeTraffic = true;
+            settings.general.vehicleCount = 10;
+            settings.vehicles.Add(new VehicleEntry { prefab = MakePrefabLike("Car"), percentage = 50f });
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "vehicles" && !i.isWarning && i.message.Contains("100")));
+        }
+
+        [Test]
+        public void ValidateDetailed_PedestrianPercentagesSummingTo100_IsValid()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.general.includePedestrians = true;
+            settings.general.pedestrianCount = 10;
+            settings.pedestrians.Add(new PedestrianEntry { prefab = MakePrefabLike("Ped"), percentage = 100f });
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsTrue(valid, string.Join("; ", issues.ConvertAll(i => i.message)));
+        }
+
+        [Test]
+        public void ValidateDetailed_RunSpeedBelowWalkSpeed_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.player.walkSpeed = 8f;
+            settings.player.runSpeed = 4f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "player.runSpeed" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_ZeroWalkSpeed_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.player.walkSpeed = 0f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "player.walkSpeed" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_EqualWalkAndRunSpeed_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.player.walkSpeed = 5f;
+            settings.player.runSpeed = 5f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "player.walkSpeed" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_ControllerStepOffsetNotSmallerThanHeight_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.player.controllerHeight = 1f;
+            settings.player.controllerStepOffset = 1f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "player.controllerStepOffset" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_ControllerSkinWidthNotSmallerThanRadius_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.player.controllerRadius = 0.2f;
+            settings.player.controllerSkinWidth = 0.2f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "player.controllerSkinWidth" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_CameraMaxPitchNotGreaterThanMinPitch_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.camera.minPitch = 10f;
+            settings.camera.maxPitch = 10f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "camera.maxPitch" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_CameraDistanceBelowMinDistance_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.camera.minDistance = 5f;
+            settings.camera.distance = 1f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "camera.distance" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_PedestrianIdleStopMaxBelowMin_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.pedestrianBehaviour.idleStopDurationMin = 10f;
+            settings.pedestrianBehaviour.idleStopDurationMax = 1f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "pedestrianBehaviour.idleStopDurationMax" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_PedestrianPoiStopMaxBelowMin_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.pedestrianBehaviour.poiStopDurationMin = 10f;
+            settings.pedestrianBehaviour.poiStopDurationMax = 1f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "pedestrianBehaviour.poiStopDurationMax" && !i.isWarning));
+        }
+
+        [Test]
+        public void ValidateDetailed_NegativeCrowdSeparationRadius_IsBlocking()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.crowd.separationRadius = -1f;
+
+            bool valid = CityGeneratorValidator.ValidateDetailed(settings, out List<CityGeneratorValidationIssue> issues);
+
+            Assert.IsFalse(valid);
+            Assert.IsTrue(issues.Exists(i => i.settingsPath == "crowd.separationRadius" && !i.isWarning));
+        }
+
+        [Test]
+        public void Validate_MirrorsValidateDetailed_OnlyReturningBlockingMessages()
+        {
+            CityGeneratorSettings settings = MakeMinimalValidSettings();
+            settings.buildingPrefabs.Add(null); // warning only
+
+            bool valid = CityGeneratorValidator.Validate(settings, out List<string> errors);
+
+            Assert.IsTrue(valid);
+            Assert.AreEqual(0, errors.Count);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/CityGeneratorValidatorTests.cs.meta
+++ b/Assets/Tests/EditMode/CityGeneratorValidatorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2716bfff4dd37624fb0e2b75b35bf905

--- a/Assets/Tests/EditMode/Generation.meta
+++ b/Assets/Tests/EditMode/Generation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6376c1b4f09ee9e488c7b8f8a9cdd155
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Generation/SeededGenerationTests.cs
+++ b/Assets/Tests/EditMode/Generation/SeededGenerationTests.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using CityGenerator.Editor;
+using CityGenerator.Runtime;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace CityGenerator.Tests.EditMode.Generation
+{
+    /// <summary>
+    /// Full-pipeline generation with a fixed seed, on the grid sizes this spec's baseline
+    /// measurements use (1x3, 5x5, 10x10). Every builder places content via `transform.localPosition`
+    /// under the city root, so offsetting the root's own world position moves the whole generated
+    /// city with it -- used here to keep each fixture far away from this project's own currently-open
+    /// scene (City.unity, with a real generated city sitting at/near world origin) and from each
+    /// other, so PedestrianNetwork.Build()'s Physics-based obstacle pruning never sees unrelated
+    /// real geometry.
+    /// </summary>
+    internal class SeededGenerationTests
+    {
+        private readonly List<GameObject> spawnedRoots = new();
+        private float nextOffset;
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (GameObject root in spawnedRoots)
+            {
+                if (root != null)
+                    Object.DestroyImmediate(root);
+            }
+            spawnedRoots.Clear();
+        }
+
+        private Transform CreateOffsetCityRoot(string name)
+        {
+            var root = new GameObject(name);
+            root.transform.position = new Vector3(nextOffset, 0f, nextOffset);
+            nextOffset += 5000f;
+            spawnedRoots.Add(root);
+            return root.transform;
+        }
+
+        private static CityGeneratorSettings MakeSettings(int gridWidth, int gridHeight, int seed)
+        {
+            var settings = new CityGeneratorSettings();
+            CityGeneratorDefaultAssets.ApplyTo(settings);
+            settings.general.gridWidth = gridWidth;
+            settings.general.gridHeight = gridHeight;
+            settings.general.useCustomSeed = true;
+            settings.general.seed = seed;
+            return settings;
+        }
+
+        [TestCase(1, 3)]
+        [TestCase(5, 5)]
+        [TestCase(10, 10)]
+        public void Assemble_FixedSeed_CompletesWithoutExceptions_AndProducesExpectedInvariants(int gridWidth, int gridHeight)
+        {
+            CityGeneratorSettings settings = MakeSettings(gridWidth, gridHeight, seed: 12345);
+            Transform root = CreateOffsetCityRoot($"City_{gridWidth}x{gridHeight}");
+
+            CityBuildSummary summary = default;
+            Assert.DoesNotThrow(() => summary = CityGeneratorContentAssembler.Assemble(settings, root));
+
+            Assert.AreEqual(gridWidth * gridHeight, summary.blockCount, "Block count must match grid dimensions.");
+            Assert.Greater(summary.buildingCount, 0, "At least one building must be placed.");
+
+            var pedestrianNetwork = root.GetComponentInChildren<PedestrianNetwork>();
+            Assert.IsNotNull(pedestrianNetwork, "PedestrianNetwork must always be generated, regardless of Include Pedestrians.");
+            Assert.Greater(pedestrianNetwork.NodeCount, 0);
+
+            var trafficNetwork = root.GetComponentInChildren<TrafficNetwork>();
+            Assert.IsNotNull(trafficNetwork, "TrafficNetwork must always be generated, regardless of Include Traffic.");
+            Assert.Greater(trafficNetwork.NodeCount, 0);
+        }
+
+        [Test]
+        public void Assemble_SameSeed_ProducesIdenticalBuildingLayout()
+        {
+            CityGeneratorSettings settingsA = MakeSettings(5, 5, seed: 777);
+            CityGeneratorSettings settingsB = MakeSettings(5, 5, seed: 777);
+
+            Transform rootA = CreateOffsetCityRoot("CityA");
+            Transform rootB = CreateOffsetCityRoot("CityB");
+
+            CityGeneratorContentAssembler.Assemble(settingsA, rootA);
+            CityGeneratorContentAssembler.Assemble(settingsB, rootB);
+
+            List<Vector3> positionsA = CollectBuildingLocalPositions(rootA);
+            List<Vector3> positionsB = CollectBuildingLocalPositions(rootB);
+            List<string> prefabsA = CollectBuildingPrefabNames(rootA);
+            List<string> prefabsB = CollectBuildingPrefabNames(rootB);
+
+            Assert.Greater(positionsA.Count, 0);
+            Assert.AreEqual(positionsA.Count, positionsB.Count, "Same seed must place the same number of buildings.");
+            CollectionAssert.AreEqual(prefabsA, prefabsB, "Same seed must pick the same prefab for each building slot, in the same order.");
+            for (int i = 0; i < positionsA.Count; i++)
+                Assert.AreEqual(positionsA[i], positionsB[i], $"Building {i} diverged between two runs with the same seed.");
+        }
+
+        [Test]
+        public void Assemble_DifferentSeeds_ProduceDifferentBuildingLayout()
+        {
+            CityGeneratorSettings settingsA = MakeSettings(5, 5, seed: 1);
+            CityGeneratorSettings settingsB = MakeSettings(5, 5, seed: 2);
+
+            Transform rootA = CreateOffsetCityRoot("CityA");
+            Transform rootB = CreateOffsetCityRoot("CityB");
+
+            CityGeneratorContentAssembler.Assemble(settingsA, rootA);
+            CityGeneratorContentAssembler.Assemble(settingsB, rootB);
+
+            List<string> prefabsA = CollectBuildingPrefabNames(rootA);
+            List<string> prefabsB = CollectBuildingPrefabNames(rootB);
+
+            CollectionAssert.AreNotEqual(prefabsA, prefabsB);
+        }
+
+        private static List<Vector3> CollectBuildingLocalPositions(Transform root)
+        {
+            Transform buildings = root.Find("Buildings");
+            var positions = new List<Vector3>();
+            foreach (Transform blockGroup in buildings)
+            {
+                foreach (Transform building in blockGroup)
+                    positions.Add(building.localPosition);
+            }
+            return positions;
+        }
+
+        /// <summary>
+        /// Building instances are renamed to a fixed "Building_x_y_slot" scheme regardless of
+        /// which prefab was chosen, so their GameObject name can't distinguish prefab choices
+        /// between two runs -- the underlying prefab asset name (via the instance's corresponding
+        /// source object) is what actually reflects the seeded random pick.
+        /// </summary>
+        private static List<string> CollectBuildingPrefabNames(Transform root)
+        {
+            Transform buildings = root.Find("Buildings");
+            var names = new List<string>();
+            foreach (Transform blockGroup in buildings)
+            {
+                foreach (Transform building in blockGroup)
+                {
+                    GameObject source = PrefabUtility.GetCorrespondingObjectFromSource(building.gameObject);
+                    names.Add(source != null ? source.name : building.name);
+                }
+            }
+            return names;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Generation/SeededGenerationTests.cs.meta
+++ b/Assets/Tests/EditMode/Generation/SeededGenerationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3a5c44e257374564ba229353118ccafd

--- a/Assets/Tests/EditMode/PedestrianNetworkTests.cs
+++ b/Assets/Tests/EditMode/PedestrianNetworkTests.cs
@@ -1,0 +1,187 @@
+using CityGenerator.Runtime;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CityGenerator.Tests.EditMode
+{
+    internal class PedestrianNetworkTests
+    {
+        private GameObject go;
+        private GameObject ground;
+        private PedestrianNetwork network;
+
+        // EditMode tests run against whatever scene is currently open in the Editor (this
+        // project's own City.unity, with a real generated city), not an isolated empty scene.
+        // Placing this fixture's synthetic ring far from the origin keeps PrunePlacedObstacles'
+        // Physics queries (run at the end of every Build()) from colliding with real scene
+        // geometry that happens to share the same layout coordinates.
+        private const float Offset = 1000000f;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // PrunePlacedObstacles (called at the end of every Build()) raycasts straight down
+            // from each node to confirm it has ground under it; without any collider under this
+            // fixture's own (far away) nodes that raycast always misses and every node ends up
+            // wrongly Blocked.
+            ground = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            ground.name = "Ground";
+            ground.transform.position = new Vector3(Offset, -10f, Offset);
+            ground.transform.localScale = new Vector3(500f, 20f, 500f);
+            Physics.SyncTransforms();
+
+            go = new GameObject("PedestrianNetwork");
+            network = go.AddComponent<PedestrianNetwork>();
+            // 2x2 blocks, no TrafficLightIntersection in the scene: each block's ring is its own
+            // isolated connected component (no crossing chains link them), which is exactly what
+            // BFS/connectivity needs to exercise.
+            network.SetAxes(new float[] { Offset - 56f, Offset, Offset + 56f }, new float[] { Offset - 56f, Offset, Offset + 56f });
+            network.Build();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (go != null) Object.DestroyImmediate(go);
+            if (ground != null) Object.DestroyImmediate(ground);
+        }
+
+        [Test]
+        public void FindPath_BetweenTwoNodesOnTheSameRing_FindsAShortestPath()
+        {
+            // Ring nodes for the first block are added first, in a fixed 8-node cycle order:
+            // sw(0) sMid(1) se(2) eMid(3) ne(4) nMid(5) nw(6) wMid(7). sw <-> se should be 2 hops
+            // going either way around the 8-node ring.
+            var path = new int[16];
+            int length = network.FindPath(0, 2, path);
+
+            Assert.Greater(length, 0);
+            Assert.AreEqual(0, path[0]);
+            Assert.AreEqual(2, path[length - 1]);
+            Assert.AreEqual(3, length); // sw -> sMid -> se
+        }
+
+        [Test]
+        public void FindPath_SameStartAndEnd_ReturnsSingleNodePath()
+        {
+            var path = new int[4];
+            int length = network.FindPath(0, 0, path);
+
+            Assert.AreEqual(1, length);
+            Assert.AreEqual(0, path[0]);
+        }
+
+        [Test]
+        public void FindPath_UnreachableNode_ReturnsZero()
+        {
+            // Node 0 (block (0,0) ring) and a node belonging to the diagonal block (1,1)'s ring
+            // are not connected: no TrafficLightIntersection exists in this scene to wire a
+            // crossing chain between blocks.
+            var path = new int[64];
+            int otherBlockRingStart = 8 * 3; // block index 3 in row-major (bi,bj) order for a 2x2 grid
+            int length = network.FindPath(0, otherBlockRingStart, path);
+
+            Assert.AreEqual(0, length);
+        }
+
+        [Test]
+        public void FindPath_ThroughBlockedNode_IsRejected()
+        {
+            // sw(0) -> sMid(1) -> se(2) is the short way around; block sMid and force the long way.
+            network.SetBlocked(1, true);
+            var path = new int[16];
+            int length = network.FindPath(0, 2, path);
+
+            Assert.Greater(length, 0);
+            CollectionAssert.DoesNotContain(path.GetRangeSubset(length), 1);
+        }
+
+        [Test]
+        public void RegisterPointOfInterest_SurvivesRebuild()
+        {
+            int ringNode = 0; // sw corner of block (0,0)
+            Vector3 poiPosition = network.GetNode(ringNode).Position + new Vector3(1f, 0f, 1f);
+            int poiIndex = network.RegisterPointOfInterest(poiPosition, poiPosition, ringNode);
+
+            // FindPath immediately after registering (before any rebuild) works.
+            var path = new int[8];
+            int length = network.FindPath(ringNode, poiIndex, path);
+            Assert.Greater(length, 0);
+
+            // Build() wipes `nodes` from scratch: the POI must be replayed from its serialized
+            // descriptor, at a *new* index (nodes are rebuilt in the same deterministic order, so
+            // it lands back at the same index here, but the test only relies on FindNearestNode).
+            network.Build();
+
+            int poiAfterRebuild = network.FindNearestNode(poiPosition, PedestrianNodeKind.PointOfInterest);
+            Assert.GreaterOrEqual(poiAfterRebuild, 0);
+
+            var pathAfterRebuild = new int[8];
+            int lengthAfterRebuild = network.FindPath(0, poiAfterRebuild, pathAfterRebuild);
+            Assert.Greater(lengthAfterRebuild, 0, "POI connection did not survive Build().");
+        }
+
+        [Test]
+        public void ComponentOf_IsolatedRings_AreDifferentComponents()
+        {
+            // Node 0 belongs to block (0,0)'s ring; node 8 is the first node of block (0,1)'s ring
+            // (see BuildBlockRing's fixed 8-nodes-per-block order) -- isolated from each other with
+            // no TrafficLightIntersection to wire a crossing chain between them.
+            Assert.AreNotEqual(network.ComponentOf(0), network.ComponentOf(8));
+        }
+
+        [Test]
+        public void PickRandomDestination_WithRequiredComponent_NeverReturnsAnotherComponent()
+        {
+            int requiredComponent = network.ComponentOf(0);
+
+            for (int attempt = 0; attempt < 20; attempt++)
+            {
+                int candidate = network.PickRandomDestination(requiredComponent);
+                if (candidate >= 0)
+                    Assert.AreEqual(requiredComponent, network.ComponentOf(candidate));
+            }
+        }
+
+        [Test]
+        public void RegisterPointOfInterest_RepeatedlyAfterBuild_DoesNotThrow()
+        {
+            // Regression test: registering several POIs after Build() (as
+            // CityGeneratorPedestrianBuilder.RegisterPointsOfInterest does once per plaza block)
+            // used to grow `nodes` without keeping the ComponentOf/PickRandomDestination-backing
+            // array in sync, throwing IndexOutOfRangeException the next time a pedestrian picked a
+            // destination.
+            for (int i = 0; i < 5; i++)
+            {
+                Vector3 poiPosition = network.GetNode(0).Position + new Vector3(i, 0f, i);
+                int poiIndex = network.RegisterPointOfInterest(poiPosition, poiPosition, 0);
+                Assert.AreEqual(network.ComponentOf(0), network.ComponentOf(poiIndex));
+            }
+
+            Assert.DoesNotThrow(() =>
+            {
+                for (int attempt = 0; attempt < 50; attempt++)
+                    network.PickRandomDestination(network.ComponentOf(0));
+            });
+        }
+
+        [Test]
+        public void CanCross_NoIntersectionMatched_AlwaysAllowed()
+        {
+            // With no TrafficLightIntersection in the scene, no Crossing nodes exist at all in
+            // this fixture's graph, so any node index queried here is a Ring node -- CanCross must
+            // return true for anything that isn't a real Crossing node tied to an intersection.
+            Assert.IsTrue(network.CanCross(0));
+        }
+    }
+
+    internal static class PedestrianNetworkTestExtensions
+    {
+        public static int[] GetRangeSubset(this int[] array, int length)
+        {
+            var result = new int[length];
+            System.Array.Copy(array, result, length);
+            return result;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/PedestrianNetworkTests.cs.meta
+++ b/Assets/Tests/EditMode/PedestrianNetworkTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 10777c0c5d061584c947b588279ba63b

--- a/Assets/Tests/EditMode/TrafficNetworkRouteWeightTests.cs
+++ b/Assets/Tests/EditMode/TrafficNetworkRouteWeightTests.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using CityGenerator.Runtime;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CityGenerator.Tests.EditMode
+{
+    /// <summary>
+    /// TrafficNetwork.RouteWeight/Ring are private (no generation-time need to expose them), so
+    /// this test drives them by reflection rather than widening their visibility just for tests.
+    /// </summary>
+    internal class TrafficNetworkRouteWeightTests
+    {
+        private GameObject go;
+        private TrafficNetwork network;
+        private MethodInfo ringMethod;
+        private MethodInfo routeWeightMethod;
+
+        [SetUp]
+        public void SetUp()
+        {
+            go = new GameObject("TrafficNetwork");
+            network = go.AddComponent<TrafficNetwork>();
+
+            // 5x5 axes: index 2 is the exact centre (interior), 0/4 are the perimeter.
+            network.SetAxes(new float[] { -112f, -56f, 0f, 56f, 112f }, new float[] { -112f, -56f, 0f, 56f, 112f });
+            network.Build();
+
+            ringMethod = typeof(TrafficNetwork).GetMethod("Ring", BindingFlags.NonPublic | BindingFlags.Instance);
+            routeWeightMethod = typeof(TrafficNetwork).GetMethod("RouteWeight", BindingFlags.NonPublic | BindingFlags.Instance);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (go != null) Object.DestroyImmediate(go);
+        }
+
+        private float Ring(int i, int j) => (float)ringMethod.Invoke(network, new object[] { i, j });
+
+        private float RouteWeight(float baseWeight, int fromI, int fromJ, int toI, int toJ)
+            => (float)routeWeightMethod.Invoke(network, new object[] { baseWeight, fromI, fromJ, toI, toJ });
+
+        [Test]
+        public void Ring_CentreIntersection_IsZero()
+        {
+            Assert.AreEqual(0f, Ring(2, 2), 0.0001f);
+        }
+
+        [Test]
+        public void Ring_CornerIntersection_IsMaximal()
+        {
+            Assert.AreEqual(2f, Ring(0, 0), 0.0001f);
+            Assert.AreEqual(2f, Ring(4, 4), 0.0001f);
+        }
+
+        [Test]
+        public void RouteWeight_MovingTowardsInterior_AppliesInteriorBias()
+        {
+            float weight = RouteWeight(1f, 0, 2, 1, 2); // perimeter -> next ring in
+            Assert.Greater(weight, 1f);
+        }
+
+        [Test]
+        public void RouteWeight_MovingTowardsPerimeter_KeepsBaseWeight()
+        {
+            float weight = RouteWeight(1f, 1, 2, 0, 2); // interior -> perimeter
+            Assert.AreEqual(1f, weight, 0.0001f);
+        }
+
+        [Test]
+        public void RouteWeight_StayingOnPerimeterRing_IsPenalized()
+        {
+            float weight = RouteWeight(1f, 0, 1, 0, 2); // both on the outermost ring
+            Assert.Less(weight, 1f);
+        }
+
+        [Test]
+        public void RouteWeight_StayingOnInteriorRing_KeepsBaseWeight()
+        {
+            float weight = RouteWeight(1f, 1, 2, 2, 1); // both ring distance 1 (interior), not perimeter
+            Assert.AreEqual(1f, weight, 0.0001f);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/TrafficNetworkRouteWeightTests.cs.meta
+++ b/Assets/Tests/EditMode/TrafficNetworkRouteWeightTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce923d6c962d0b6498f56cb7b319657e

--- a/Assets/Tests/Performance.meta
+++ b/Assets/Tests/Performance.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e58b36ad95162c148a956fced969e9a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Performance/CityGenerator.Tests.Performance.asmdef
+++ b/Assets/Tests/Performance/CityGenerator.Tests.Performance.asmdef
@@ -1,0 +1,25 @@
+{
+    "name": "CityGenerator.Tests.Performance",
+    "rootNamespace": "CityGenerator.Tests.Performance",
+    "references": [
+        "CityGenerator.Runtime",
+        "CityGenerator.Editor",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Unity.InputSystem",
+        "Unity.PerformanceTesting"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Performance/CityGenerator.Tests.Performance.asmdef.meta
+++ b/Assets/Tests/Performance/CityGenerator.Tests.Performance.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8b3a0f802d74dd94597c43874f00900c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Performance/GenerationPerformanceTests.cs
+++ b/Assets/Tests/Performance/GenerationPerformanceTests.cs
@@ -1,0 +1,93 @@
+using CityGenerator.Editor;
+using NUnit.Framework;
+using Unity.PerformanceTesting;
+using UnityEngine;
+
+namespace CityGenerator.Tests.Performance
+{
+    /// <summary>
+    /// Baseline generation-time/GC-alloc measurements for the grid sizes this spec's item 7
+    /// (spatial hash) baseline/delta comparison uses. Purely informational (see the spec's
+    /// "no numeric threshold" decision) -- these are read from the Test Runner's result window
+    /// or its exported results, then copied into the spec/PR by hand.
+    /// </summary>
+    internal class GenerationPerformanceTests
+    {
+        private GameObject root;
+        private float offset;
+
+        private CityGeneratorSettings MakeSettings(int gridWidth, int gridHeight)
+        {
+            var settings = new CityGeneratorSettings();
+            CityGeneratorDefaultAssets.ApplyTo(settings);
+            settings.general.gridWidth = gridWidth;
+            settings.general.gridHeight = gridHeight;
+            settings.general.useCustomSeed = true;
+            settings.general.seed = 42;
+            return settings;
+        }
+
+        private void SetUpRoot()
+        {
+            root = new GameObject("PerfCity");
+            root.transform.position = new Vector3(offset, 0f, offset);
+            offset += 5000f;
+        }
+
+        private void CleanUpRoot()
+        {
+            if (root != null)
+                Object.DestroyImmediate(root);
+        }
+
+        private void MeasureGeneration(int gridWidth, int gridHeight)
+        {
+            CityGeneratorSettings settings = MakeSettings(gridWidth, gridHeight);
+
+            Measure.Method(() =>
+                {
+                    CityGeneratorContentAssembler.Assemble(settings, root.transform);
+                })
+                .SetUp(SetUpRoot)
+                .CleanUp(CleanUpRoot)
+                .WarmupCount(1)
+                .MeasurementCount(5)
+                .GC()
+                .Run();
+        }
+
+        [Test, Performance]
+        public void GenerationTime_1x3() => MeasureGeneration(1, 3);
+
+        [Test, Performance]
+        public void GenerationTime_5x5() => MeasureGeneration(5, 5);
+
+        [Test, Performance]
+        public void GenerationTime_10x10() => MeasureGeneration(10, 10);
+
+        /// <summary>
+        /// Rough managed-memory footprint of a generated city: GC.GetTotalMemory before/after,
+        /// forcing a collection first so the delta reflects genuinely new live objects rather than
+        /// whatever garbage happened to be pending. Approximate by nature (doesn't account for
+        /// native/graphics memory the instantiated GameObjects/meshes/materials also hold) -- see
+        /// the spec's "informative data, not a blocking threshold" decision.
+        /// </summary>
+        [Test, Performance]
+        public void ApproxManagedMemory_5x5()
+        {
+            SetUpRoot();
+            CityGeneratorSettings settings = MakeSettings(5, 5);
+
+            System.GC.Collect();
+            long before = System.GC.GetTotalMemory(true);
+
+            CityGeneratorContentAssembler.Assemble(settings, root.transform);
+
+            long after = System.GC.GetTotalMemory(false);
+
+            Measure.Custom(new SampleGroup("ApproxManagedMemoryDelta", SampleUnit.Megabyte), (after - before) / (1024.0 * 1024.0));
+
+            CleanUpRoot();
+        }
+    }
+}

--- a/Assets/Tests/Performance/GenerationPerformanceTests.cs.meta
+++ b/Assets/Tests/Performance/GenerationPerformanceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 66046de6782ce6646910071d444cc511

--- a/Assets/Tests/Performance/RuntimePerformanceTests.cs
+++ b/Assets/Tests/Performance/RuntimePerformanceTests.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using CityGenerator.Editor;
+using NUnit.Framework;
+using Unity.PerformanceTesting;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CityGenerator.Tests.Performance
+{
+    /// <summary>
+    /// Baseline per-frame runtime cost with a generated city's traffic + pedestrians actively
+    /// ticking (TrafficManager/PedestrianManager Update, CarAgent/PedestrianAgent sensors,
+    /// Physics.SyncTransforms), at the three agent loads this spec's items 8-9 baseline/delta
+    /// comparison uses. Measures whole-frame time rather than isolating each subsystem with its
+    /// own ProfilerMarker (none of the production code carries one) -- informational only, per the
+    /// spec's "no numeric threshold" decision; read from the Test Runner / exported results and
+    /// copied into the spec/PR by hand.
+    /// </summary>
+    internal class RuntimePerformanceTests
+    {
+        private GameObject root;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (root != null)
+                Object.DestroyImmediate(root);
+        }
+
+        private IEnumerator BuildCityWithAgents(int vehicleCount, int pedestrianCount)
+        {
+            var settings = new CityGeneratorSettings();
+            CityGeneratorDefaultAssets.ApplyTo(settings);
+            settings.general.gridWidth = 10;
+            settings.general.gridHeight = 10;
+            settings.general.useCustomSeed = true;
+            settings.general.seed = 99;
+            settings.general.includeTraffic = true;
+            settings.general.vehicleCount = vehicleCount;
+            settings.general.includePedestrians = true;
+            settings.general.pedestrianCount = pedestrianCount;
+
+            root = new GameObject("PerfRuntimeCity");
+            root.transform.position = new Vector3(20000f, 0f, 20000f);
+            CityGeneratorContentAssembler.Assemble(settings, root.transform);
+
+            // A few frames so every agent's Start() (initial destination planning, node lookup) has
+            // run before measurement starts -- otherwise the first measured frames would include
+            // one-off spawn cost instead of steady-state ticking.
+            yield return null;
+            yield return null;
+            yield return null;
+        }
+
+        [UnityTest, Performance]
+        public IEnumerator PerFrameCost_60Agents()
+        {
+            yield return BuildCityWithAgents(60, 60);
+            yield return Measure.Frames().WarmupCount(10).MeasurementCount(60).Run();
+        }
+
+        [UnityTest, Performance]
+        public IEnumerator PerFrameCost_150Agents()
+        {
+            yield return BuildCityWithAgents(150, 150);
+            yield return Measure.Frames().WarmupCount(10).MeasurementCount(60).Run();
+        }
+
+        [UnityTest, Performance]
+        public IEnumerator PerFrameCost_300Agents()
+        {
+            yield return BuildCityWithAgents(300, 300);
+            yield return Measure.Frames().WarmupCount(10).MeasurementCount(60).Run();
+        }
+    }
+}

--- a/Assets/Tests/Performance/RuntimePerformanceTests.cs.meta
+++ b/Assets/Tests/Performance/RuntimePerformanceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61e5fb17e74c4f94788ab2acf65a79c5

--- a/Assets/Tests/PlayMode.meta
+++ b/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c08f79b019221904683c70542fe8ae36
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/CityGenerator.Tests.PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/CityGenerator.Tests.PlayMode.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "CityGenerator.Tests.PlayMode",
+    "rootNamespace": "CityGenerator.Tests.PlayMode",
+    "references": [
+        "CityGenerator.Runtime",
+        "CityGenerator.Editor",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Unity.InputSystem"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/PlayMode/CityGenerator.Tests.PlayMode.asmdef.meta
+++ b/Assets/Tests/PlayMode/CityGenerator.Tests.PlayMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d9ad24de87466224ebdc98b61331426c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/ColliderOnChildDetectionTests.cs
+++ b/Assets/Tests/PlayMode/ColliderOnChildDetectionTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Reflection;
+using CityGenerator.Editor;
+using CityGenerator.Runtime;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CityGenerator.Tests.PlayMode
+{
+    /// <summary>
+    /// SPEC 04 fixed CityGeneratorColliderUtility so a prefab whose only Collider lives on a
+    /// child (never the root) still ends up with a root-level, non-trigger proxy -- required for
+    /// CarAgent's ColliderRegistry-based sensor identity check (CarAgent.OnEnable does a
+    /// root-only GetComponent&lt;Collider&gt;()). This was previously verified manually; this test
+    /// automates it.
+    /// </summary>
+    internal class ColliderOnChildDetectionTests
+    {
+        private static object GetStatic(System.Type type, string field)
+        {
+            FieldInfo info = type.GetField(field, BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(info, $"Static field '{field}' not found on {type}");
+            return info.GetValue(null);
+        }
+
+        [Test]
+        public void EnsureNonTriggerCollider_WithColliderOnlyOnChild_AddsRootProxy_LeavesChildUntouched()
+        {
+            var root = new GameObject("VehicleLikePrefabInstance");
+            var child = new GameObject("Body");
+            child.transform.SetParent(root.transform);
+            BoxCollider childCollider = child.AddComponent<BoxCollider>();
+            childCollider.isTrigger = true; // simulate a purely physical/decorative child collider
+            child.AddComponent<MeshRenderer>();
+            child.AddComponent<MeshFilter>();
+
+            Assert.IsNull(root.GetComponent<Collider>(), "Fixture invariant: root must start with no collider.");
+
+            Collider proxy = CityGeneratorColliderUtility.EnsureNonTriggerCollider(root);
+
+            Assert.AreSame(root, proxy.gameObject, "The proxy collider must live on the instance root.");
+            Assert.IsFalse(proxy.isTrigger);
+            Assert.IsTrue(childCollider.isTrigger, "A collider deeper in the hierarchy must be left completely untouched.");
+
+            Object.Destroy(root);
+        }
+
+        [Test]
+        public void CarAgent_WithColliderOnlyOnChildBeforeProxyAssignment_RegistersItsRootProxy()
+        {
+            // Own TrafficNetwork/Manager pair, wired before the agent is ever enabled: otherwise
+            // CarAgent.OnEnable's FindAnyObjectByType<TrafficNetwork> fallback could resolve the
+            // real generated city in this project's own currently-open scene instead.
+            var networkGo = new GameObject("TrafficNetwork");
+            TrafficNetwork network = networkGo.AddComponent<TrafficNetwork>();
+            TrafficManager manager = networkGo.AddComponent<TrafficManager>();
+            typeof(TrafficNetwork).GetField("manager", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(network, manager);
+
+            var root = new GameObject("VehicleLikePrefabInstance");
+            root.SetActive(false);
+            var child = new GameObject("Body");
+            child.transform.SetParent(root.transform);
+            child.AddComponent<BoxCollider>();
+
+            // Mirrors CityGeneratorTrafficBuilder.BuildVehicles: the collider policy runs before
+            // CarAgent is ever added/enabled.
+            CityGeneratorColliderUtility.EnsureNonTriggerCollider(root);
+            CarAgent agent = root.AddComponent<CarAgent>();
+            typeof(CarAgent).GetField("network", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(agent, network);
+
+            root.SetActive(true); // triggers OnEnable: GetComponent<Collider>() must now find the root proxy
+
+            var registry = (System.Collections.IDictionary)GetStatic(typeof(CarAgent), "ColliderRegistry");
+            bool found = false;
+            foreach (System.Collections.DictionaryEntry entry in registry)
+            {
+                if (ReferenceEquals(entry.Value, agent))
+                {
+                    found = true;
+                    break;
+                }
+            }
+            Assert.IsTrue(found, "CarAgent must register under its root proxy collider's entity id, even though the prefab's only original collider was on a child.");
+
+            Object.Destroy(root);
+            Object.Destroy(networkGo);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/ColliderOnChildDetectionTests.cs.meta
+++ b/Assets/Tests/PlayMode/ColliderOnChildDetectionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b20b1eafda5418346a30ffcacdb45b54

--- a/Assets/Tests/PlayMode/ManagerRegistrationTests.cs
+++ b/Assets/Tests/PlayMode/ManagerRegistrationTests.cs
@@ -1,0 +1,154 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using CityGenerator.Runtime;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CityGenerator.Tests.PlayMode
+{
+    /// <summary>
+    /// TrafficManager/PedestrianManager registration is driven entirely from CarAgent/PedestrianAgent
+    /// OnEnable/OnDisable, which run synchronously on SetActive (not deferred like Start()) -- no
+    /// need to wait a frame for these tests. Every agent here is built while its GameObject is
+    /// inactive so its `network` field can be wired by reflection *before* OnEnable runs (fired by
+    /// the SetActive(true) that follows) -- otherwise OnEnable's FindAnyObjectByType<TrafficNetwork>
+    /// fallback could resolve the real generated city in this project's own currently-open scene
+    /// instead of this test's fixture.
+    /// </summary>
+    internal class ManagerRegistrationTests
+    {
+        private static object GetPrivate(object target, string field)
+        {
+            FieldInfo info = target.GetType().GetField(field, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(info, $"Field '{field}' not found on {target.GetType()}");
+            return info.GetValue(target);
+        }
+
+        private static void SetField(object target, string field, object value)
+        {
+            FieldInfo info = target.GetType().GetField(field, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(info, $"Field '{field}' not found on {target.GetType()}");
+            info.SetValue(target, value);
+        }
+
+        private static GameObject BuildInactiveCarAgent(string name, TrafficNetwork network, out CarAgent agent)
+        {
+            var go = new GameObject(name);
+            go.SetActive(false);
+            agent = go.AddComponent<CarAgent>();
+            SetField(agent, "network", network);
+            return go;
+        }
+
+        private static GameObject BuildInactivePedestrianAgent(string name, PedestrianNetwork network, out PedestrianAgent agent)
+        {
+            var go = new GameObject(name);
+            go.SetActive(false);
+            go.AddComponent<Animator>();
+            agent = go.AddComponent<PedestrianAgent>();
+            SetField(agent, "network", network);
+            return go;
+        }
+
+        private static (TrafficNetwork network, TrafficManager manager) BuildTrafficNetworkWithManager(string name)
+        {
+            var go = new GameObject(name);
+            TrafficNetwork network = go.AddComponent<TrafficNetwork>();
+            TrafficManager manager = go.AddComponent<TrafficManager>();
+            SetField(network, "manager", manager);
+            return (network, manager);
+        }
+
+        [Test]
+        public void CarAgent_RegistersOnEnable_AndUnregistersOnDisable()
+        {
+            (TrafficNetwork network, TrafficManager manager) = BuildTrafficNetworkWithManager("TrafficNetwork");
+            GameObject carGo = BuildInactiveCarAgent("Car", network, out _);
+            var agents = (HashSet<CarAgent>)GetPrivate(manager, "agents");
+
+            carGo.SetActive(true);
+            Assert.AreEqual(1, agents.Count);
+
+            carGo.SetActive(false);
+            Assert.AreEqual(0, agents.Count);
+
+            carGo.SetActive(true);
+            Assert.AreEqual(1, agents.Count, "Re-enabling must re-register exactly once.");
+
+            Object.Destroy(carGo);
+            Object.Destroy(network.gameObject);
+        }
+
+        [Test]
+        public void PedestrianAgent_RegistersOnEnable_AndUnregistersOnDisable()
+        {
+            var networkGo = new GameObject("PedestrianNetwork");
+            PedestrianNetwork network = networkGo.AddComponent<PedestrianNetwork>();
+            PedestrianManager manager = networkGo.AddComponent<PedestrianManager>();
+            SetField(network, "manager", manager);
+
+            GameObject pedGo = BuildInactivePedestrianAgent("Pedestrian", network, out _);
+            var agents = (List<PedestrianAgent>)GetPrivate(manager, "agents");
+
+            pedGo.SetActive(true);
+            Assert.AreEqual(1, agents.Count);
+
+            pedGo.SetActive(false);
+            Assert.AreEqual(0, agents.Count);
+
+            pedGo.SetActive(true);
+            Assert.AreEqual(1, agents.Count, "Re-enabling must re-register exactly once.");
+
+            Object.Destroy(pedGo);
+            Object.Destroy(networkGo);
+        }
+
+        [UnityTest]
+        public IEnumerator TrafficManager_WithNoRegisteredAgents_SkipsUpdateEntirely()
+        {
+            // Item 8 (stages 1-2): Physics.SyncTransforms() moved from TrafficNetwork.LateUpdate
+            // into TrafficManager.Update, called only when there's at least one registered agent.
+            // frameIndex only advances past the early-return guard, so watching it never move is a
+            // faithful proxy for "Update (and the SyncTransforms call within it) never really ran".
+            var networkGo = new GameObject("TrafficNetwork");
+            TrafficNetwork network = networkGo.AddComponent<TrafficNetwork>();
+            TrafficManager manager = networkGo.AddComponent<TrafficManager>();
+            SetField(network, "manager", manager);
+
+            yield return null;
+            yield return null;
+
+            object frameIndex = GetPrivate(manager, "frameIndex");
+            Assert.AreEqual(0, frameIndex, "TrafficManager.Update must return before advancing frameIndex when no CarAgent is registered.");
+
+            Object.Destroy(networkGo);
+        }
+
+        [Test]
+        public void TwoIndependentNetworks_EachManagerOnlyTicksItsOwnAgents()
+        {
+            (TrafficNetwork networkA, TrafficManager managerA) = BuildTrafficNetworkWithManager("CityA");
+            (TrafficNetwork networkB, TrafficManager managerB) = BuildTrafficNetworkWithManager("CityB");
+
+            GameObject carA = BuildInactiveCarAgent("CarA", networkA, out CarAgent agentA);
+            GameObject carB = BuildInactiveCarAgent("CarB", networkB, out CarAgent agentB);
+            carA.SetActive(true);
+            carB.SetActive(true);
+
+            var agentsA = (HashSet<CarAgent>)GetPrivate(managerA, "agents");
+            var agentsB = (HashSet<CarAgent>)GetPrivate(managerB, "agents");
+
+            Assert.AreEqual(1, agentsA.Count);
+            Assert.AreEqual(1, agentsB.Count);
+            CollectionAssert.DoesNotContain(agentsA, agentB);
+            CollectionAssert.DoesNotContain(agentsB, agentA);
+
+            Object.Destroy(carA);
+            Object.Destroy(carB);
+            Object.Destroy(networkA.gameObject);
+            Object.Destroy(networkB.gameObject);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/ManagerRegistrationTests.cs.meta
+++ b/Assets/Tests/PlayMode/ManagerRegistrationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d9f1362f0f87c9c449312b2d703fcb66

--- a/Assets/Tests/PlayMode/PedestrianCanCrossTests.cs
+++ b/Assets/Tests/PlayMode/PedestrianCanCrossTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Reflection;
+using CityGenerator.Runtime;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CityGenerator.Tests.PlayMode
+{
+    /// <summary>
+    /// Exercises PedestrianNetwork.CanCross against a directly-wired TrafficLightIntersection,
+    /// bypassing the geometry-matching Build() normally performs (covered separately by the
+    /// EditMode pathfinding tests) so the light-state logic itself can be tested in isolation.
+    /// </summary>
+    internal class PedestrianCanCrossTests
+    {
+        private GameObject networkGo;
+        private PedestrianNetwork network;
+        private GameObject intersectionGo;
+        private TrafficLightIntersection intersection;
+        private TrafficLight eastWestLight;
+        private int crossingNodeIndex;
+
+        [SetUp]
+        public void SetUp()
+        {
+            networkGo = new GameObject("PedestrianNetwork");
+            network = networkGo.AddComponent<PedestrianNetwork>();
+
+            intersectionGo = new GameObject("Intersection");
+            intersection = intersectionGo.AddComponent<TrafficLightIntersection>();
+            var ewGo = new GameObject("EW");
+            eastWestLight = ewGo.AddComponent<TrafficLight>();
+            var nsGo = new GameObject("NS");
+            TrafficLight nsLight = nsGo.AddComponent<TrafficLight>();
+            SetPrivate(intersection, "eastWest", new List<TrafficLight> { eastWestLight });
+            SetPrivate(intersection, "northSouth", new List<TrafficLight> { nsLight });
+
+            var trafficNetworkGo = new GameObject("TrafficNetwork");
+            TrafficNetwork trafficNetwork = trafficNetworkGo.AddComponent<TrafficNetwork>();
+            SetPrivate(network, "trafficNetwork", trafficNetwork);
+
+            crossingNodeIndex = network.AddNode(Vector3.zero, PedestrianNodeKind.Crossing);
+            List<PedestrianNode> nodes = (List<PedestrianNode>)GetPrivate(network, "nodes");
+            PedestrianNode node = nodes[crossingNodeIndex];
+            node.Intersection = intersection;
+            node.CrossingAxisIsX = true;
+            nodes[crossingNodeIndex] = node;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.Destroy(networkGo);
+            Object.Destroy(intersectionGo);
+            if (eastWestLight != null) Object.Destroy(eastWestLight.gameObject);
+        }
+
+        private static void SetPrivate(object target, string field, object value)
+        {
+            FieldInfo info = target.GetType().GetField(field, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(info, $"Field '{field}' not found on {target.GetType()}");
+            info.SetValue(target, value);
+        }
+
+        private static object GetPrivate(object target, string field)
+        {
+            FieldInfo info = target.GetType().GetField(field, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(info, $"Field '{field}' not found on {target.GetType()}");
+            return info.GetValue(target);
+        }
+
+        [Test]
+        public void CanCross_WhenAxisIsRed_ReturnsTrue()
+        {
+            eastWestLight.SetState(TrafficLightState.Red);
+            Assert.IsTrue(network.CanCross(crossingNodeIndex));
+        }
+
+        [Test]
+        public void CanCross_WhenAxisIsGreen_ReturnsFalse()
+        {
+            eastWestLight.SetState(TrafficLightState.Green);
+            Assert.IsFalse(network.CanCross(crossingNodeIndex));
+        }
+
+        [Test]
+        public void CanCross_WhenAxisIsAmber_ReturnsFalse()
+        {
+            // Amber still has cars moving/braking through: only Red is safe to step onto.
+            eastWestLight.SetState(TrafficLightState.Amber);
+            Assert.IsFalse(network.CanCross(crossingNodeIndex));
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/PedestrianCanCrossTests.cs.meta
+++ b/Assets/Tests/PlayMode/PedestrianCanCrossTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 09e79dc1d861f9f47868013987e2272b

--- a/Assets/Tests/PlayMode/PedestrianRoadProximityGridTests.cs
+++ b/Assets/Tests/PlayMode/PedestrianRoadProximityGridTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Reflection;
+using CityGenerator.Runtime;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CityGenerator.Tests.PlayMode
+{
+    /// <summary>
+    /// Regression coverage for a real bug: once PedestrianRoadProximityGrid.HasEnoughAgents goes
+    /// true, CarAgent.PedestrianAheadClearance stops SphereCasting and answers from this grid
+    /// alone -- but the player is on the same Pedestrian layer as every NPC (and the SphereCast
+    /// sensor always saw it) without ever being a PedestrianAgent itself, so it could never be one
+    /// of the grid's bucketed entries. Cars stopped detecting/braking for the player entirely once
+    /// enough pedestrians were spawned. Fixed by tracking the player separately (see
+    /// TryGetPlayerPosition) and having CarAgent check it explicitly alongside the grid query.
+    /// </summary>
+    internal class PedestrianRoadProximityGridTests
+    {
+        private GameObject gridGo;
+        private PedestrianRoadProximityGrid grid;
+
+        [SetUp]
+        public void SetUp()
+        {
+            gridGo = new GameObject("RoadProximityGrid");
+            grid = gridGo.AddComponent<PedestrianRoadProximityGrid>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (gridGo != null) Object.Destroy(gridGo);
+        }
+
+        [Test]
+        public void Rebuild_WithPlayerTransform_TryGetPlayerPositionReturnsIt()
+        {
+            var playerGo = new GameObject("Player");
+            playerGo.transform.position = new Vector3(5f, 0f, 7f);
+
+            grid.Rebuild(new List<PedestrianAgent>(), minAgentCountToUse: 0, player: playerGo.transform);
+
+            Assert.IsTrue(grid.TryGetPlayerPosition(out Vector3 position));
+            Assert.AreEqual(playerGo.transform.position, position);
+
+            Object.Destroy(playerGo);
+        }
+
+        [Test]
+        public void Rebuild_WithNoPlayerTransform_TryGetPlayerPositionReturnsFalse()
+        {
+            grid.Rebuild(new List<PedestrianAgent>(), minAgentCountToUse: 0, player: null);
+
+            Assert.IsFalse(grid.TryGetPlayerPosition(out _));
+        }
+
+        [Test]
+        public void CarAgent_WithHasEnoughAgentsButNoPedestrianAgents_StillDetectsPlayer()
+        {
+            // No PedestrianAgent instances registered at all (0 NPCs, e.g. Include Pedestrians
+            // off) but the grid still reports HasEnoughAgents once minAgentCountToUse is 0 -- the
+            // exact scenario that silently blinded CarAgent to the player before this fix.
+            var playerGo = new GameObject("Player");
+            playerGo.transform.position = new Vector3(0f, 0f, 5f);
+            // HasEnoughAgents is `agents.Count > minAgentCountToUse`: -1 forces it true even with
+            // zero registered PedestrianAgents (0 NPCs is exactly the scenario that hid this bug).
+            grid.Rebuild(new List<PedestrianAgent>(), minAgentCountToUse: -1, player: playerGo.transform);
+            Assert.IsTrue(grid.HasEnoughAgents);
+
+            var carGo = new GameObject("Car");
+            CarAgent car = carGo.AddComponent<CarAgent>();
+            typeof(CarAgent).GetField("pedestrianRoadProximity", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(car, grid);
+            typeof(CarAgent).GetField("sensorRange", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(car, 12f);
+            typeof(CarAgent).GetField("minGap", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(car, 2.2f);
+
+            MethodInfo method = typeof(CarAgent).GetMethod("PedestrianAheadClearance", BindingFlags.NonPublic | BindingFlags.Instance);
+            float clearance = (float)method.Invoke(car, null);
+
+            Assert.Less(clearance, float.MaxValue, "CarAgent must still detect the player via the grid path, not report an unobstructed lane.");
+
+            Object.Destroy(carGo);
+            Object.Destroy(playerGo);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/PedestrianRoadProximityGridTests.cs.meta
+++ b/Assets/Tests/PlayMode/PedestrianRoadProximityGridTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0b5fd71b0fb159440bbfaf0068805a13

--- a/Assets/Tests/PlayMode/TrafficLightIntersectionCycleTests.cs
+++ b/Assets/Tests/PlayMode/TrafficLightIntersectionCycleTests.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using CityGenerator.Runtime;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CityGenerator.Tests.PlayMode
+{
+    internal class TrafficLightIntersectionCycleTests
+    {
+        private static void SetPrivate(object target, string field, object value)
+        {
+            FieldInfo info = target.GetType().GetField(field, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(info, $"Field '{field}' not found on {target.GetType()}");
+            info.SetValue(target, value);
+        }
+
+        [UnityTest]
+        public IEnumerator RunCycle_AlternatesGreenBetweenAxes_WithAmberAndAllRedPhases()
+        {
+            var go = new GameObject("Intersection");
+            var intersection = go.AddComponent<TrafficLightIntersection>();
+
+            var ewGo = new GameObject("EW");
+            TrafficLight ew = ewGo.AddComponent<TrafficLight>();
+            var nsGo = new GameObject("NS");
+            TrafficLight ns = nsGo.AddComponent<TrafficLight>();
+
+            // Each phase boundary is checked shortly after it should have started, with enough
+            // headroom before the *next* boundary that frame-timing jitter can't spill the check
+            // into the following phase (each cumulative wait lands comfortably inside its target
+            // phase's window, well short of the next one).
+            const float phase = 1f;
+            const float stepWait = phase + 0.2f;
+            SetPrivate(intersection, "eastWest", new List<TrafficLight> { ew });
+            SetPrivate(intersection, "northSouth", new List<TrafficLight> { ns });
+            SetPrivate(intersection, "greenDuration", phase);
+            SetPrivate(intersection, "amberDuration", phase);
+            SetPrivate(intersection, "allRedDuration", phase);
+
+            // Start() runs on the next frame after AddComponent, kicking off RunCycle(), which
+            // sets both Red then immediately (no startOffset) sets eastWest Green -- all
+            // synchronous within that same frame, before RunCycle's first yield.
+            yield return null;
+            Assert.AreEqual(TrafficLightState.Green, ew.State);
+            Assert.AreEqual(TrafficLightState.Red, ns.State);
+
+            yield return new WaitForSeconds(stepWait); // ~1.2s: green (0-1s) has ended, now in amber (1-2s)
+            Assert.AreEqual(TrafficLightState.Amber, ew.State, "Expected amber after the green phase.");
+
+            yield return new WaitForSeconds(stepWait); // ~2.4s: amber (1-2s) has ended, now in all-red (2-3s)
+            Assert.AreEqual(TrafficLightState.Red, ew.State, "Expected all-red after the amber phase.");
+            Assert.AreEqual(TrafficLightState.Red, ns.State);
+
+            yield return new WaitForSeconds(stepWait); // ~3.6s: all-red (2-3s) has ended, now north-south green (3-4s)
+            Assert.AreEqual(TrafficLightState.Green, ns.State, "Expected the north-south axis to get green next.");
+            Assert.AreEqual(TrafficLightState.Red, ew.State);
+
+            Object.Destroy(go);
+            Object.Destroy(ewGo);
+            Object.Destroy(nsGo);
+        }
+
+        [UnityTest]
+        public IEnumerator StartOffset_DelaysTheFirstCycle()
+        {
+            var go = new GameObject("Intersection");
+            var intersection = go.AddComponent<TrafficLightIntersection>();
+            var ewGo = new GameObject("EW");
+            TrafficLight ew = ewGo.AddComponent<TrafficLight>();
+            var nsGo = new GameObject("NS");
+            TrafficLight ns = nsGo.AddComponent<TrafficLight>();
+
+            SetPrivate(intersection, "eastWest", new List<TrafficLight> { ew });
+            SetPrivate(intersection, "northSouth", new List<TrafficLight> { ns });
+            SetPrivate(intersection, "greenDuration", 0.15f);
+            SetPrivate(intersection, "amberDuration", 0.15f);
+            SetPrivate(intersection, "allRedDuration", 0.15f);
+            SetPrivate(intersection, "startOffset", 0.2f);
+
+            yield return null;
+            // Still within the offset window: both red.
+            Assert.AreEqual(TrafficLightState.Red, ew.State);
+            Assert.AreEqual(TrafficLightState.Red, ns.State);
+
+            yield return new WaitForSeconds(0.3f);
+            Assert.AreEqual(TrafficLightState.Green, ew.State, "Cycle should have started after the offset elapsed.");
+
+            Object.Destroy(go);
+            Object.Destroy(ewGo);
+            Object.Destroy(nsGo);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/TrafficLightIntersectionCycleTests.cs.meta
+++ b/Assets/Tests/PlayMode/TrafficLightIntersectionCycleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 078e01dc6a2498e439f61284a737bdc0

--- a/Packages/com.santiandrade.citygenerator/CHANGELOG.md
+++ b/Packages/com.santiandrade.citygenerator/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-08-26
+
+### Added
+
+- A test suite (`Assets/Tests/`, outside the package): EditMode tests for the pedestrian network's
+  `CanCross` rules, connected-component routing and `PedestrianRoadProximityGrid`; PlayMode tests
+  for `TrafficLightIntersection`'s phase cycle, manager registration/deregistration and
+  collider-on-child detection; and Performance tests measuring a baseline generation and runtime
+  frame cost. Baseline/delta measurements are recorded in `specs/05-performance-and-tests.md`.
+
+### Changed
+
+- `CityGeneratorPlacementEngine`'s overlap check now queries a spatial hash
+  (`CityGeneratorSpatialHash`) over the shared obstacles list instead of scanning it linearly per
+  candidate (measured -17.2% total generation time on a 10x10 grid).
+- `Physics.SyncTransforms` moved from `TrafficNetwork` to `TrafficManager.Update`, and is only
+  called when at least one `CarAgent` is registered.
+- `CarAgent`'s forward vehicle sensor now scans an `OverlapSphere` centred on the car's own
+  position instead of a `SphereCast` from a point offset ahead of it, closing a blind spot where a
+  long vehicle (a `Truck`/`Garbage-Truck`) a couple of metres ahead could go undetected; the new
+  `TrafficLaneOccupancy` fast path resolves "car ahead in the same lane segment" without a
+  `SphereCast` at all, measuring the gap to the other car's actual collider surface (via its new
+  `OwnCollider` property) instead of centre-to-centre, so a queue of cars no longer settles with
+  their bodies visibly overlapping.
+- `PedestrianNetwork` now computes connected components so `PedestrianAgent.PlanNewDestination`
+  never attempts a route to an unreachable part of the graph; each agent's initial destination
+  planning is staggered by spawn index instead of every agent planning on the same frame;
+  `FindPath` caches the full BFS tree per origin instead of recomputing it for every candidate
+  destination tried; and `PedestrianAgent` rents its path buffer from a shared
+  `PedestrianPathBufferPool` instead of keeping a permanent per-agent array sized to the whole
+  graph. `PedestrianManager`'s local-separation pass now processes each agent pair once instead of
+  twice and skips pairs where neither side is due for a recalculation this frame.
+- `CarAgent` can now query nearby pedestrians through `PedestrianRoadProximityGrid` instead of its
+  own `SphereCast`, once the pedestrian count justifies it (same staggering threshold as vehicle
+  detection). `PedestrianManager` feeds the grid the player's position separately from registered
+  `PedestrianAgent` instances, since the player is on the same `Pedestrian` layer without being one
+  — without this, once the pedestrian count crossed the staggering threshold, vehicles stopped
+  detecting and braking for the player.
+
+### Fixed
+
+- `CarAgent`'s "ahead" direction is now the vector toward its own current target node instead of
+  `transform.forward`: mid-corner, `RotateTowards` keeps a car's heading lagging behind its actual
+  path for the whole turn, which could put another car rounding the same corner a few metres away
+  outside the forward cone.
+- Fixed an `IndexOutOfRangeException` when a plaza's `PointOfInterest` node was registered after
+  `PedestrianNetwork.Build()`, growing the node list without keeping the connected-components array
+  in sync (regression introduced while implementing the connected-components routing above; caught
+  by the new runtime performance tests and covered by a regression test).
+
 ## [2.0.0] - 2026-08-25
 
 ### Changed

--- a/Packages/com.santiandrade.citygenerator/Editor/AssemblyInfo.cs
+++ b/Packages/com.santiandrade.citygenerator/Editor/AssemblyInfo.cs
@@ -7,3 +7,12 @@ using System.Runtime.CompilerServices;
 // internal/private exactly as before: this is the one visibility change needed for the moved
 // "Set Current Selection As Default" command to keep working.
 [assembly: InternalsVisibleTo("Assembly-CSharp-Editor")]
+
+// SPEC 05: lets Assets/Tests/{EditMode,PlayMode,Performance} (this repo's own dev tooling,
+// outside the package, same convention as Assembly-CSharp-Editor above) exercise the internal
+// generation classes (CityGeneratorGrid, CityGeneratorDistributionUtility, CityGeneratorValidator,
+// CityGeneratorPlacementEngine, CityGeneratorSpatialHash, ...) directly instead of through
+// reflection.
+[assembly: InternalsVisibleTo("CityGenerator.Tests.EditMode")]
+[assembly: InternalsVisibleTo("CityGenerator.Tests.PlayMode")]
+[assembly: InternalsVisibleTo("CityGenerator.Tests.Performance")]

--- a/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorPedestrianBuilder.cs
+++ b/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorPedestrianBuilder.cs
@@ -61,6 +61,7 @@ namespace CityGenerator.Editor
         public static void AddManagerComponent(Transform pedestrianNetworkGroup, PedestrianNetwork network, CrowdSettings settings)
         {
             PedestrianManager manager = pedestrianNetworkGroup.gameObject.AddComponent<PedestrianManager>();
+            PedestrianRoadProximityGrid roadProximity = pedestrianNetworkGroup.gameObject.AddComponent<PedestrianRoadProximityGrid>();
 
             var serialized = new SerializedObject(manager);
             serialized.FindProperty("staggerMinAgentCount").intValue = settings.staggerMinAgentCount;
@@ -71,10 +72,13 @@ namespace CityGenerator.Editor
             serialized.FindProperty("separationStrength").floatValue = settings.separationStrength;
             serialized.FindProperty("playerAvoidanceRadius").floatValue = settings.playerAvoidanceRadius;
             serialized.FindProperty("playerAvoidanceStrength").floatValue = settings.playerAvoidanceStrength;
+            serialized.FindProperty("roadProximityGrid").objectReferenceValue = roadProximity;
+            serialized.FindProperty("network").objectReferenceValue = network;
             serialized.ApplyModifiedPropertiesWithoutUndo();
 
             var networkSerialized = new SerializedObject(network);
             networkSerialized.FindProperty("manager").objectReferenceValue = manager;
+            networkSerialized.FindProperty("roadProximity").objectReferenceValue = roadProximity;
             networkSerialized.ApplyModifiedPropertiesWithoutUndo();
         }
 
@@ -164,6 +168,7 @@ namespace CityGenerator.Editor
 
                     var serializedAgent = new SerializedObject(agent);
                     serializedAgent.FindProperty("network").objectReferenceValue = network;
+                    serializedAgent.FindProperty("spawnIndex").intValue = placed.Count;
                     serializedAgent.FindProperty("walkReferenceSpeed").floatValue = behaviour.walkReferenceSpeed;
                     serializedAgent.FindProperty("runReferenceSpeed").floatValue = behaviour.runReferenceSpeed;
                     serializedAgent.FindProperty("paceFraction").floatValue = behaviour.paceFraction;

--- a/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorPlacementEngine.cs
+++ b/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorPlacementEngine.cs
@@ -31,6 +31,12 @@ namespace CityGenerator.Editor
         private readonly Dictionary<GameObject, Rect> rects = new();
         private readonly Dictionary<GameObject, GameObject> availableProbes = new();
 
+        // Auxiliary index over the obstacles list threaded through a whole generation run (item
+        // 7): never the source of truth, just a derived structure kept in sync with it via
+        // SyncSpatialHash, so it can never disagree with what the list itself contains.
+        private readonly CityGeneratorSpatialHash spatialHash = new(CityGeneratorConstants.BlockSize);
+        private int indexedObstacleCount;
+
         public Rect GetRect(GameObject instance)
         {
             if (rects.TryGetValue(instance, out Rect cached))
@@ -41,6 +47,25 @@ namespace CityGenerator.Editor
             rects[instance] = rect;
             return rect;
         }
+
+        /// <summary>
+        /// Inserts every obstacle appended to <paramref name="obstacles"/> since the last call into
+        /// the spatial hash. Cheap to call before every overlap check: since obstacles are only
+        /// ever appended (never removed/reordered) across a whole generation run, this only ever
+        /// does work for the entries actually added since the last sync.
+        /// </summary>
+        public void SyncSpatialHash(List<GameObject> obstacles)
+        {
+            for (int i = indexedObstacleCount; i < obstacles.Count; i++)
+            {
+                GameObject obstacle = obstacles[i];
+                if (obstacle != null)
+                    spatialHash.Insert(GetRect(obstacle));
+            }
+            indexedObstacleCount = obstacles.Count;
+        }
+
+        public bool SpatialHashOverlaps(Rect candidate) => spatialHash.Overlaps(candidate);
 
         public GameObject BorrowProbe(GameObject prefab, Transform parent, PlacementCandidate candidate)
         {
@@ -133,18 +158,13 @@ namespace CityGenerator.Editor
 
         private static bool OverlapsAny(GameObject instance, List<GameObject> others, ObstacleCache cache)
         {
+            // `instance` (the probe being tested) is never itself a member of `others`: it's only
+            // ever appended to the shared obstacles list *after* being accepted, at which point the
+            // next candidate borrows a fresh probe instead of reusing this one -- so, unlike the
+            // pre-item-7 linear scan, no self-exclusion check is needed here.
+            cache.SyncSpatialHash(others);
             Rect rectA = cache.GetRect(instance);
-
-            foreach (GameObject other in others)
-            {
-                if (other == instance)
-                    continue;
-
-                if (rectA.Overlaps(cache.GetRect(other)))
-                    return true;
-            }
-
-            return false;
+            return cache.SpatialHashOverlaps(rectA);
         }
     }
 }

--- a/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorSpatialHash.cs
+++ b/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorSpatialHash.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CityGenerator.Editor
+{
+    /// <summary>
+    /// Uniform spatial hash over XZ <see cref="Rect"/>s, used by <see cref="CityGeneratorPlacementEngine"/>
+    /// to avoid a linear scan of every already-placed obstacle on each overlap check. Purely an
+    /// index: it never owns the obstacle list itself, so it can't drift out of sync with it as
+    /// long as every insertion mirrors what gets added to that list (see
+    /// <see cref="ObstacleCache.SyncSpatialHash"/>).
+    /// </summary>
+    internal sealed class CityGeneratorSpatialHash
+    {
+        private readonly float cellSize;
+        private readonly Dictionary<(int x, int z), List<Rect>> cells = new();
+
+        public CityGeneratorSpatialHash(float cellSize)
+        {
+            this.cellSize = cellSize;
+        }
+
+        /// <summary>Registers <paramref name="bounds"/> in every cell it overlaps.</summary>
+        public void Insert(Rect bounds)
+        {
+            (int minX, int minZ) = CellOf(bounds.xMin, bounds.yMin);
+            (int maxX, int maxZ) = CellOf(bounds.xMax, bounds.yMax);
+
+            for (int x = minX; x <= maxX; x++)
+            {
+                for (int z = minZ; z <= maxZ; z++)
+                {
+                    var key = (x, z);
+                    if (!cells.TryGetValue(key, out List<Rect> bucket))
+                    {
+                        bucket = new List<Rect>();
+                        cells[key] = bucket;
+                    }
+                    bucket.Add(bounds);
+                }
+            }
+        }
+
+        /// <summary>True if any previously-inserted rect overlaps <paramref name="candidate"/>. Only
+        /// queries the candidate's own cells and their neighbours, not every inserted rect.</summary>
+        public bool Overlaps(Rect candidate)
+        {
+            (int minX, int minZ) = CellOf(candidate.xMin, candidate.yMin);
+            (int maxX, int maxZ) = CellOf(candidate.xMax, candidate.yMax);
+
+            for (int x = minX; x <= maxX; x++)
+            {
+                for (int z = minZ; z <= maxZ; z++)
+                {
+                    if (!cells.TryGetValue((x, z), out List<Rect> bucket))
+                        continue;
+
+                    for (int i = 0; i < bucket.Count; i++)
+                    {
+                        if (bucket[i].Overlaps(candidate))
+                            return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private (int x, int z) CellOf(float x, float z)
+            => (Mathf.FloorToInt(x / cellSize), Mathf.FloorToInt(z / cellSize));
+    }
+}

--- a/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorSpatialHash.cs.meta
+++ b/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorSpatialHash.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d636b0a2d344774093213389dbc5407

--- a/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorTrafficBuilder.cs
+++ b/Packages/com.santiandrade.citygenerator/Editor/CityGeneratorTrafficBuilder.cs
@@ -45,9 +45,11 @@ namespace CityGenerator.Editor
         public static void AddManagerComponent(Transform trafficNetworkGroup, TrafficNetwork network)
         {
             var manager = trafficNetworkGroup.gameObject.AddComponent<TrafficManager>();
+            var laneOccupancy = trafficNetworkGroup.gameObject.AddComponent<TrafficLaneOccupancy>();
 
             var serialized = new SerializedObject(network);
             serialized.FindProperty("manager").objectReferenceValue = manager;
+            serialized.FindProperty("laneOccupancy").objectReferenceValue = laneOccupancy;
             serialized.ApplyModifiedPropertiesWithoutUndo();
         }
 

--- a/Packages/com.santiandrade.citygenerator/Runtime/CarAgent.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/CarAgent.cs
@@ -55,6 +55,12 @@ namespace CityGenerator.Runtime
 
         private readonly RaycastHit[] hits = new RaycastHit[16];
         private readonly RaycastHit[] pedestrianHits = new RaycastHit[16];
+        // Resolved lazily on first use (not OnEnable): a generated vehicle's OnEnable fires during
+        // generation itself, before CityGeneratorPedestrianBuilder has created this GameObject --
+        // vehicles are built first. By the time Play actually starts and the sensor first runs, the
+        // full scene (including this) exists.
+        private PedestrianRoadProximityGrid pedestrianRoadProximity;
+        private readonly List<PedestrianAgent> pedestrianQueryResults = new();
 
         // Own identifier for crossing reservations; 0 means "crossing free".
         private static int nextCarId = 1;
@@ -72,6 +78,10 @@ namespace CityGenerator.Runtime
         private Collider ownCollider;
         private TrafficManager trafficManager;
         private int targetNode = -1;
+        // Node the vehicle most recently departed from -- together with targetNode, identifies the
+        // directed lane segment it currently occupies in TrafficNetwork.LaneOccupancy. -1 before
+        // the first segment is known (nothing to report as "departed from" yet).
+        private int fromNode = -1;
         private int reservedIntersection = -1;
         private int carId;
         private float speed;
@@ -157,6 +167,8 @@ namespace CityGenerator.Runtime
                 trafficManager.Unregister(this);
                 trafficManager = null;
             }
+            if (network != null && network.LaneOccupancy != null && targetNode >= 0)
+                network.LaneOccupancy.Leave(this, fromNode, targetNode);
         }
 
         private void Start()
@@ -181,6 +193,8 @@ namespace CityGenerator.Runtime
                 enabled = false;
                 return;
             }
+
+            network.LaneOccupancy?.Enter(this, fromNode, targetNode);
         }
 
         /// <summary>
@@ -328,9 +342,24 @@ namespace CityGenerator.Runtime
             return mustStop ? toStopLine : float.MaxValue;
         }
 
-        /// <summary>Clear distance to the car ahead, minus the minimum gap.</summary>
+        /// <summary>
+        /// Clear distance to the car ahead, minus the minimum gap. Tries
+        /// <see cref="TrafficNetwork.LaneOccupancy"/> first for the common "another car ahead on
+        /// this same lane segment" case (item 8, stage 3) -- cheap, no physics query -- and only
+        /// falls back to the SphereCast sensor below when it has no answer (empty/absent segment,
+        /// a car about to turn, or genuine cross-traffic at a crossing, none of which the index
+        /// attempts to resolve). The two opposing-traffic deadlock rules below only ever fire from
+        /// the SphereCast path: cars sharing one directed lane segment share the same heading by
+        /// construction, so they can never be "head-on" to each other.
+        /// </summary>
         private float VehicleAheadClearance()
         {
+            if (network.LaneOccupancy != null && network.LaneOccupancy.TryGetCarAhead(this, fromNode, targetNode, out CarAgent laneAhead))
+            {
+                float laneDistance = Vector3.Distance(transform.position, laneAhead.transform.position);
+                return laneDistance <= 0.001f ? 0f : laneDistance - minGap;
+            }
+
             Vector3 origin = transform.position + Vector3.up * 0.9f + transform.forward * 2.2f;
             int count = Physics.SphereCastNonAlloc(origin, sensorRadius, transform.forward, hits,
                 sensorRange, vehicleMask, QueryTriggerInteraction.Ignore);
@@ -386,6 +415,16 @@ namespace CityGenerator.Runtime
         /// </summary>
         private float PedestrianAheadClearance()
         {
+            if (pedestrianRoadProximity == null)
+                pedestrianRoadProximity = FindAnyObjectByType<PedestrianRoadProximityGrid>();
+
+            // Item 8, stage 4: once the pedestrian count justifies it, query the shared proximity
+            // grid instead of casting -- falls back to the SphereCast below whenever the grid
+            // doesn't exist (no PedestrianManager in the scene, e.g. Include Pedestrians off) or
+            // hasn't reported enough agents yet.
+            if (pedestrianRoadProximity != null && pedestrianRoadProximity.HasEnoughAgents)
+                return PedestrianAheadClearanceFromGrid();
+
             Vector3 origin = transform.position + Vector3.up * 0.9f + transform.forward * 2.2f;
             int count = Physics.SphereCastNonAlloc(origin, sensorRadius, transform.forward, pedestrianHits,
                 sensorRange, pedestrianMask, QueryTriggerInteraction.Collide);
@@ -399,6 +438,31 @@ namespace CityGenerator.Runtime
             for (int i = 0; i < count; i++)
             {
                 float gap = pedestrianHits[i].distance <= 0.001f ? 0f : pedestrianHits[i].distance - minGap;
+                clearance = Mathf.Min(clearance, gap);
+            }
+
+            return clearance;
+        }
+
+        /// <summary>
+        /// Same intent as the SphereCast fallback above, answered from
+        /// <see cref="PedestrianRoadProximityGrid"/> instead: only pedestrians roughly ahead (a
+        /// forward-dot check, mirroring the cast's cone) within sensorRange count.
+        /// </summary>
+        private float PedestrianAheadClearanceFromGrid()
+        {
+            Vector3 origin = transform.position + Vector3.up * 0.9f + transform.forward * 2.2f;
+            pedestrianRoadProximity.QueryNear(origin, sensorRange, pedestrianQueryResults);
+
+            float clearance = float.MaxValue;
+            for (int i = 0; i < pedestrianQueryResults.Count; i++)
+            {
+                Vector3 toPedestrian = pedestrianQueryResults[i].transform.position - origin;
+                float distance = toPedestrian.magnitude;
+                if (distance > 0.001f && Vector3.Dot(toPedestrian / distance, transform.forward) < 0.5f)
+                    continue;
+
+                float gap = distance <= 0.001f ? 0f : distance - minGap;
                 clearance = Mathf.Min(clearance, gap);
             }
 
@@ -472,7 +536,10 @@ namespace CityGenerator.Runtime
 
             if (next >= 0)
             {
+                network.LaneOccupancy?.Leave(this, fromNode, targetNode);
+                fromNode = targetNode;
                 targetNode = next;
+                network.LaneOccupancy?.Enter(this, fromNode, targetNode);
             }
         }
 

--- a/Packages/com.santiandrade.citygenerator/Runtime/CarAgent.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/CarAgent.cs
@@ -447,7 +447,10 @@ namespace CityGenerator.Runtime
         /// <summary>
         /// Same intent as the SphereCast fallback above, answered from
         /// <see cref="PedestrianRoadProximityGrid"/> instead: only pedestrians roughly ahead (a
-        /// forward-dot check, mirroring the cast's cone) within sensorRange count.
+        /// forward-dot check, mirroring the cast's cone) within sensorRange count. The player is on
+        /// the same Pedestrian layer as every NPC and the SphereCast sensor always detected it, but
+        /// the player is never itself a PedestrianAgent, so it can never be one of the grid's own
+        /// bucketed entries -- checked separately via TryGetPlayerPosition instead.
         /// </summary>
         private float PedestrianAheadClearanceFromGrid()
         {
@@ -464,6 +467,17 @@ namespace CityGenerator.Runtime
 
                 float gap = distance <= 0.001f ? 0f : distance - minGap;
                 clearance = Mathf.Min(clearance, gap);
+            }
+
+            if (pedestrianRoadProximity.TryGetPlayerPosition(out Vector3 playerPosition))
+            {
+                Vector3 toPlayer = playerPosition - origin;
+                float distance = toPlayer.magnitude;
+                if (distance <= sensorRange && (distance <= 0.001f || Vector3.Dot(toPlayer / distance, transform.forward) >= 0.5f))
+                {
+                    float gap = distance <= 0.001f ? 0f : distance - minGap;
+                    clearance = Mathf.Min(clearance, gap);
+                }
             }
 
             return clearance;

--- a/Packages/com.santiandrade.citygenerator/Runtime/CarAgent.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/CarAgent.cs
@@ -53,8 +53,12 @@ namespace CityGenerator.Runtime
         [Tooltip("Seconds a car keeps pushing through once it starts breaking a deadlock.")]
         [SerializeField] private float deadlockBreakDuration = 4f;
 
-        private readonly RaycastHit[] hits = new RaycastHit[16];
         private readonly RaycastHit[] pedestrianHits = new RaycastHit[16];
+        // Sized generously above the old SphereCast sensor's 16: VehicleAheadClearance now scans
+        // every vehicle within the full sensorRange of this car's own position (see its comment),
+        // which in a dense jam can genuinely have more than 16 vehicles in range at once.
+        private readonly Collider[] overlaps = new Collider[32];
+        private readonly Collider[] pedestrianOverlaps = new Collider[16];
         // Resolved lazily on first use (not OnEnable): a generated vehicle's OnEnable fires during
         // generation itself, before CityGeneratorPedestrianBuilder has created this GameObject --
         // vehicles are built first. By the time Play actually starts and the sensor first runs, the
@@ -121,6 +125,10 @@ namespace CityGenerator.Runtime
         /// <summary>Seconds it has been continuously stopped for.</summary>
         public float StoppedTime => stoppedTime;
         public StopReason CurrentStopReason => stopReason;
+        /// <summary>Root-level proxy collider assigned by CityGeneratorColliderUtility, read by
+        /// another CarAgent's <see cref="VehicleAheadClearance"/> lane-occupancy fast path to
+        /// measure real surface distance instead of raw center-to-center distance.</summary>
+        public Collider OwnCollider => ownCollider;
 
         // Counter reset for Play sessions with Domain Reload disabled, where a static field
         // otherwise keeps growing across sessions and breaks the carId tie-break in IsDeadlockedWith.
@@ -354,56 +362,114 @@ namespace CityGenerator.Runtime
         /// </summary>
         private float VehicleAheadClearance()
         {
-            if (network.LaneOccupancy != null && network.LaneOccupancy.TryGetCarAhead(this, fromNode, targetNode, out CarAgent laneAhead))
+            // The direction actually used to decide "ahead" everywhere below, in place of
+            // transform.forward: mid-corner, RotateTowards keeps this car's heading lagging behind
+            // its actual path for the whole turn, so two cars rounding the same corner a few metres
+            // apart can have noticeably different transform.forward -- enough that a projection
+            // using either car's live heading puts the other one "behind" it, even head-on into its
+            // rear bumper. The vector to this car's own target node follows the path, not the lag,
+            // so it stays reliable through the turn.
+            TrafficNetwork.Node targetNodeInfo = network.GetNode(targetNode);
+            Vector3 towardTarget = targetNodeInfo.Position - transform.position;
+            towardTarget.y = 0f;
+            towardTarget = towardTarget.sqrMagnitude > 0.0001f ? towardTarget.normalized : transform.forward;
+
+            if (network.LaneOccupancy != null && network.LaneOccupancy.TryGetCarAhead(this, fromNode, targetNode, towardTarget, out CarAgent laneAhead))
             {
-                float laneDistance = Vector3.Distance(transform.position, laneAhead.transform.position);
+                // Measured the same way the SphereCast below measures it -- from the sensor
+                // origin (2.2m ahead of this car's centre) to the other car's actual collider
+                // surface -- not centre-to-centre. Centre-to-centre ignored both cars' own length,
+                // so a queue converging on the same lane segment settled with `minGap` between
+                // centres while their (2.5-3m long) bodies still overlapped by a couple of metres:
+                // a real pile-up, not just a visual one. Falls back to centre-to-centre only if the
+                // other car has no collider yet (shouldn't happen for a generated vehicle, but the
+                // proxy collider is assigned by the generator, not guaranteed by this component).
+                Vector3 laneOrigin = transform.position + Vector3.up * 0.9f + towardTarget * 2.2f;
+                float laneDistance = laneAhead.OwnCollider != null
+                    ? Vector3.Distance(laneOrigin, laneAhead.OwnCollider.ClosestPoint(laneOrigin))
+                    : Vector3.Distance(transform.position, laneAhead.transform.position);
                 return laneDistance <= 0.001f ? 0f : laneDistance - minGap;
             }
 
-            Vector3 origin = transform.position + Vector3.up * 0.9f + transform.forward * 2.2f;
-            int count = Physics.SphereCastNonAlloc(origin, sensorRadius, transform.forward, hits,
-                sensorRange, vehicleMask, QueryTriggerInteraction.Ignore);
+            // OverlapSphere centred on this car's own position, not on a point offset ahead of it --
+            // a SphereCast (or an OverlapSphere at that offset point) has a blind spot for any
+            // vehicle whose body spans past the offset point without its surface actually touching
+            // the small sensor sphere there, which a long vehicle (a Truck/Garbage-Truck a couple
+            // of metres ahead) triggers easily: the cast/overlap finds nothing, this car never
+            // brakes, and it drives straight into it. Scanning from the car's own centre out to the
+            // full sensorRange has no such gap; forward/lateral projection below re-applies the same
+            // narrow forward cone a directional cast gave for free, so a car in an adjacent lane
+            // still isn't mistaken for one ahead in this one.
+            Vector3 egoPosition = transform.position;
+            Vector3 origin = egoPosition + Vector3.up * 0.9f + towardTarget * 2.2f;
+            int count = Physics.OverlapSphereNonAlloc(egoPosition + Vector3.up * 0.9f, sensorRange, overlaps,
+                vehicleMask, QueryTriggerInteraction.Ignore);
 
-            if (count == hits.Length)
+            if (count == overlaps.Length)
             {
-                Debug.LogWarning($"{name}: forward sensor hit its {hits.Length}-collider limit; the closest vehicle may be missing from this frame's results.", this);
+                Debug.LogWarning($"{name}: forward sensor hit its {overlaps.Length}-collider limit; the closest vehicle may be missing from this frame's results.", this);
             }
 
             float clearance = float.MaxValue;
             for (int i = 0; i < count; i++)
             {
-                // Discarded by identity, never by distance: a zero-distance hit is
-                // the car's own collider, but also the car already bumper-to-bumper ahead, and
-                // filtering by distance made it invisible and drove into it. A hit collider that
-                // isn't in ColliderRegistry at all (rather than resolving to `this`) can no longer
-                // be a car with its collider buried in a child, out of the sensor's layer mask —
-                // CityGeneratorColliderUtility guarantees every generated vehicle has a root-level,
-                // correctly-layered collider; an unregistered hit here is unrelated scene geometry.
-                if (!ColliderRegistry.TryGetValue(hits[i].collider.GetEntityId(), out CarAgent other) || other == this)
+                Collider collider = overlaps[i];
+                Vector3 offset = collider.transform.position - egoPosition;
+                float along = Vector3.Dot(offset, towardTarget);
+                if (along <= 0f)
                 {
                     continue;
                 }
 
-                // Only head-on obstacles can deadlock: regular traffic never produces one
-                // (opposing lanes are separated by laneOffset), so this cannot fire on a queue.
-                if (Vector3.Dot(transform.forward, other.transform.forward) < -0.3f)
+                Vector3 lateral = offset - along * towardTarget;
+                if (lateral.sqrMagnitude > sensorRadius * sensorRadius)
                 {
-                    if (IsDeadlockedWith(other))
-                    {
-                        breakingDeadlockUntil = Time.time + deadlockBreakDuration;
-                    }
-
-                    if (Time.time < breakingDeadlockUntil)
-                    {
-                        continue;
-                    }
+                    continue;
                 }
 
-                float gap = hits[i].distance <= 0.001f ? 0f : hits[i].distance - minGap;
-                clearance = Mathf.Min(clearance, gap);
+                float distance = Vector3.Distance(origin, collider.ClosestPoint(origin));
+                clearance = ProcessVehicleCollider(collider, distance, clearance);
             }
 
             return clearance;
+        }
+
+        /// <summary>
+        /// Shared by the SphereCast sweep and its OverlapSphere fallback in
+        /// <see cref="VehicleAheadClearance"/>: resolves a hit collider to the other <see cref="CarAgent"/>,
+        /// applies the head-on deadlock rule, and folds its gap into <paramref name="clearance"/>.
+        /// </summary>
+        private float ProcessVehicleCollider(Collider collider, float distance, float clearance)
+        {
+            // Discarded by identity, never by distance: a zero-distance hit is
+            // the car's own collider, but also the car already bumper-to-bumper ahead, and
+            // filtering by distance made it invisible and drove into it. A hit collider that
+            // isn't in ColliderRegistry at all (rather than resolving to `this`) can no longer
+            // be a car with its collider buried in a child, out of the sensor's layer mask —
+            // CityGeneratorColliderUtility guarantees every generated vehicle has a root-level,
+            // correctly-layered collider; an unregistered hit here is unrelated scene geometry.
+            if (!ColliderRegistry.TryGetValue(collider.GetEntityId(), out CarAgent other) || other == this)
+            {
+                return clearance;
+            }
+
+            // Only head-on obstacles can deadlock: regular traffic never produces one
+            // (opposing lanes are separated by laneOffset), so this cannot fire on a queue.
+            if (Vector3.Dot(transform.forward, other.transform.forward) < -0.3f)
+            {
+                if (IsDeadlockedWith(other))
+                {
+                    breakingDeadlockUntil = Time.time + deadlockBreakDuration;
+                }
+
+                if (Time.time < breakingDeadlockUntil)
+                {
+                    return clearance;
+                }
+            }
+
+            float gap = distance <= 0.001f ? 0f : distance - minGap;
+            return Mathf.Min(clearance, gap);
         }
 
         /// <summary>
@@ -441,6 +507,15 @@ namespace CityGenerator.Runtime
                 clearance = Mathf.Min(clearance, gap);
             }
 
+            // See the `overlaps` field comment on VehicleAheadClearance: catches a pedestrian (or
+            // the player, on the same layer) already flush against the sensor origin, which the
+            // sweep above silently misses.
+            if (Physics.OverlapSphereNonAlloc(origin, sensorRadius, pedestrianOverlaps, pedestrianMask,
+                    QueryTriggerInteraction.Collide) > 0)
+            {
+                clearance = 0f;
+            }
+
             return clearance;
         }
 
@@ -457,30 +532,57 @@ namespace CityGenerator.Runtime
             Vector3 origin = transform.position + Vector3.up * 0.9f + transform.forward * 2.2f;
             pedestrianRoadProximity.QueryNear(origin, sensorRange, pedestrianQueryResults);
 
+            // The "ahead" cone is measured from this car's own centre, not from `origin`: origin
+            // already sits 2.2m ahead of centre, so a pedestrian closer than that to the car (the
+            // exact "standing right at the bumper" case) projects *behind* origin along forward,
+            // scoring a negative dot and getting filtered out as "not ahead" -- never detected, no
+            // matter how close. Distance/gap still uses `origin`, matching the SphereCast fallback's
+            // calibration of minGap.
+            Vector3 carPosition = transform.position;
             float clearance = float.MaxValue;
             for (int i = 0; i < pedestrianQueryResults.Count; i++)
             {
-                Vector3 toPedestrian = pedestrianQueryResults[i].transform.position - origin;
-                float distance = toPedestrian.magnitude;
-                if (distance > 0.001f && Vector3.Dot(toPedestrian / distance, transform.forward) < 0.5f)
+                if (!IsPedestrianInPath(pedestrianQueryResults[i].transform.position, carPosition, out float distance))
                     continue;
 
                 float gap = distance <= 0.001f ? 0f : distance - minGap;
                 clearance = Mathf.Min(clearance, gap);
             }
 
-            if (pedestrianRoadProximity.TryGetPlayerPosition(out Vector3 playerPosition))
+            if (pedestrianRoadProximity.TryGetPlayerPosition(out Vector3 playerPosition)
+                && IsPedestrianInPath(playerPosition, carPosition, out float playerDistance))
             {
-                Vector3 toPlayer = playerPosition - origin;
-                float distance = toPlayer.magnitude;
-                if (distance <= sensorRange && (distance <= 0.001f || Vector3.Dot(toPlayer / distance, transform.forward) >= 0.5f))
-                {
-                    float gap = distance <= 0.001f ? 0f : distance - minGap;
-                    clearance = Mathf.Min(clearance, gap);
-                }
+                float gap = playerDistance <= 0.001f ? 0f : playerDistance - minGap;
+                clearance = Mathf.Min(clearance, gap);
             }
 
             return clearance;
+
+            bool IsPedestrianInPath(Vector3 pedestrianPosition, Vector3 egoPosition, out float distanceFromOrigin)
+            {
+                distanceFromOrigin = 0f;
+                Vector3 fromCar = pedestrianPosition - egoPosition;
+                if (fromCar.sqrMagnitude > 0.001f)
+                {
+                    // Lateral cutoff on top of the forward cone: without it, a pedestrian standing
+                    // still on the sidewalk kerb -- never stepping onto the road -- reads as "ahead"
+                    // for several metres of approach (a wide cone reaches far to the side at range)
+                    // and the car brakes hard for someone who was never in its way. PedestrianNetwork
+                    // places a kerb roughly one lane-width-and-a-bit out from this car's own lane
+                    // centre; 1.6m keeps a pedestrian already in or stepping into this lane covered
+                    // while excluding one still waiting at the kerb.
+                    Vector3 direction = fromCar.normalized;
+                    if (Vector3.Dot(direction, transform.forward) < 0.5f)
+                        return false;
+
+                    Vector3 lateral = fromCar - Vector3.Dot(fromCar, transform.forward) * transform.forward;
+                    if (lateral.sqrMagnitude > 1.6f * 1.6f)
+                        return false;
+                }
+
+                distanceFromOrigin = Vector3.Distance(pedestrianPosition, origin);
+                return distanceFromOrigin <= sensorRange;
+            }
         }
 
         /// <summary>

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianAgent.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianAgent.cs
@@ -40,6 +40,16 @@ namespace CityGenerator.Runtime
         [SerializeField] private float rotationSpeed = 360f;
         [SerializeField] private float arriveRadius = 0.3f;
 
+        [Header("Spawn")]
+        [Tooltip("Set per-instance by CityGeneratorPedestrianBuilder.BuildPedestrians (spawn order). Used only to stagger this agent's first PlanNewDestination across several seconds instead of every agent planning on the same frame Start() runs -- see initialPlanStaggerSeconds.")]
+        [SerializeField] private int spawnIndex;
+
+        // Per-agent delay before its *first* PlanNewDestination call, item 9's answer to "every
+        // pedestrian spawned at once plans in the same frame". Reuses the existing Idling
+        // state/stopUntilTime machinery below rather than adding a new one: Start() enters Idling
+        // with a staggered stopUntilTime instead of calling PlanNewDestination directly.
+        private const float InitialPlanStaggerSeconds = 0.01f;
+
         [Header("Stops")]
         [SerializeField] private float idleStopChance = 0.3f;
         [SerializeField] private float idleStopDurationMin = 2f;
@@ -58,13 +68,12 @@ namespace CityGenerator.Runtime
         private PedestrianManager manager;
         private PedestrianState state = PedestrianState.Walking;
 
-        // A simple shortest path never revisits a node, so network.NodeCount is a hard upper
-        // bound on its length — sizing the buffer to it (allocated once, here, after `network` is
-        // known) means FindPath can only ever refuse a request for being genuinely unreachable,
-        // never for a route that's merely long. A fixed constant undercounted this badly: this
-        // graph has many hops per metre (a single street crossing alone costs 4), so with
-        // PlanNewDestination now deliberately biasing towards far destinations, routes routinely
-        // ran into a fixed-size cap that a physical-distance estimate didn't anticipate.
+        // Sized to the actual length of this agent's *current* path, grown only when a longer one
+        // is planned -- not to network.NodeCount up front. Item 9: FindPath's own output buffer
+        // (which does need the full nodeCount-worst-case size) is rented from
+        // PedestrianManager.PathBufferPool for the duration of PlanNewDestination and returned
+        // immediately after the used prefix is copied in here, instead of every agent keeping its
+        // own permanent nodeCount-sized array alive for its whole lifetime.
         private int[] path;
         private int pathLength;
         private int pathIndex;
@@ -128,8 +137,6 @@ namespace CityGenerator.Runtime
                 return;
             }
 
-            path = new int[network.NodeCount];
-
             bool isRunner = Random.value < runnerChance;
             float basePace = isRunner ? runReferenceSpeed : walkReferenceSpeed * paceFraction;
             effectiveSpeed = basePace * (1f + Random.Range(-speedJitter, speedJitter));
@@ -146,7 +153,12 @@ namespace CityGenerator.Runtime
                 return;
             }
 
-            PlanNewDestination();
+            // Staggers this agent's first PlanNewDestination instead of every spawned pedestrian
+            // planning on the same frame (Unity runs every pending Start() in one batch before the
+            // first Update, so without this every agent's initial BFS/candidate search would land
+            // in a single frame). Tick's existing Idling branch below picks this up naturally once
+            // stopUntilTime elapses -- no separate state machine needed.
+            StartIdling(spawnIndex * InitialPlanStaggerSeconds, spawnIndex * InitialPlanStaggerSeconds);
         }
 
         private void OnDisable()
@@ -300,10 +312,11 @@ namespace CityGenerator.Runtime
         {
             Vector3 fromPosition = network.GetNode(currentNode).Position;
             int candidateCount = 0;
+            int requiredComponent = network.ComponentOf(currentNode);
 
             for (int attempt = 0; attempt < DestinationCandidateAttempts; attempt++)
             {
-                int candidate = network.PickRandomDestination();
+                int candidate = network.PickRandomDestination(requiredComponent);
                 if (candidate < 0 || candidate == currentNode)
                 {
                     continue;
@@ -333,18 +346,30 @@ namespace CityGenerator.Runtime
 
             for (int i = 0; i < candidateCount; i++)
             {
-                pathLength = network.FindPath(currentNode, candidateNodes[i], path);
-                if (pathLength > 1)
+                int[] scratch = manager.PathBufferPool.Rent();
+                int length = network.FindPath(currentNode, candidateNodes[i], scratch);
+                if (length > 1)
                 {
+                    EnsurePathCapacity(length);
+                    System.Array.Copy(scratch, path, length);
+                    pathLength = length;
                     pathIndex = 1; // path[0] == currentNode
                     state = PedestrianState.Walking;
+                    manager.PathBufferPool.Return(scratch);
                     return;
                 }
+                manager.PathBufferPool.Return(scratch);
             }
 
             // None of this round's candidates were reachable (e.g. an isolated block on a 1xN
             // grid): settle briefly and try again with a fresh random draw instead of spinning.
             StartIdling(1f, 2f);
+        }
+
+        private void EnsurePathCapacity(int length)
+        {
+            if (path == null || path.Length < length)
+                path = new int[length];
         }
 
         /// <summary>

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianAgent.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianAgent.cs
@@ -395,6 +395,22 @@ namespace CityGenerator.Runtime
             return nodePosition + perpendicular.normalized * lateralOffset;
         }
 
+        // Two node-graph-timing approaches (smearing the sidewalkY/roadY step across the whole
+        // curb<->crossing segment, then chasing it from whichever end the Curb node fell on) both
+        // still guessed *when* the step should happen instead of asking where it actually is.
+        // Grounding by raycast sidesteps that entirely: the agent's Y just always matches whatever
+        // real floor collider (RoadBase/Sidewalk, both BoxColliders -- see CLAUDE.md "Demo
+        // content") sits under its current XZ, so the step happens on the exact frame the agent's
+        // feet cross the true collider edge, not an approximation of it. groundMask defaults to
+        // Default (every floor/building/prop collider) since Vehicle/Pedestrian are dynamically
+        // assigned layers created at generation time and never used for ground geometry.
+        [Header("Grounding")]
+        [Tooltip("Raycast downward each frame to find the real floor height under the agent, instead of trusting the network's own sidewalkY/roadY node heights and the timing of travel between them.")]
+        [SerializeField] private LayerMask groundMask = 1;
+
+        private const float GroundRayUpOffset = 1f;
+        private const float GroundRayDownDistance = 3f;
+
         private void MoveTowards(Vector3 targetPosition, float dt)
         {
             Vector3 flatDir = targetPosition - transform.position;
@@ -405,9 +421,27 @@ namespace CityGenerator.Runtime
                 transform.rotation = Quaternion.RotateTowards(transform.rotation, desired, rotationSpeed * dt);
             }
 
-            Vector3 nextPosition = Vector3.MoveTowards(transform.position, targetPosition, effectiveSpeed * dt);
-            distanceTravelled += Vector3.Distance(transform.position, nextPosition);
+            Vector3 currentPosition = transform.position;
+            Vector3 currentXZ = new(currentPosition.x, 0f, currentPosition.z);
+            Vector3 targetXZ = new(targetPosition.x, 0f, targetPosition.z);
+            Vector3 nextXZ = Vector3.MoveTowards(currentXZ, targetXZ, effectiveSpeed * dt);
+
+            float nextY = ResolveGroundY(nextXZ, currentPosition.y);
+            Vector3 nextPosition = new(nextXZ.x, nextY, nextXZ.z);
+
+            distanceTravelled += Vector3.Distance(currentPosition, nextPosition);
             transform.position = nextPosition;
+        }
+
+        private float ResolveGroundY(Vector3 xz, float fallbackY)
+        {
+            Vector3 origin = new(xz.x, fallbackY + GroundRayUpOffset, xz.z);
+            if (Physics.Raycast(origin, Vector3.down, out RaycastHit hit, GroundRayUpOffset + GroundRayDownDistance, groundMask, QueryTriggerInteraction.Ignore))
+            {
+                return hit.point.y;
+            }
+
+            return fallbackY;
         }
     }
 }

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianManager.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianManager.cs
@@ -132,7 +132,7 @@ namespace CityGenerator.Runtime
             ApplyLocalSeparation(dt);
             ApplyPlayerAvoidance(dt);
 
-            roadProximityGrid?.Rebuild(agents, staggerMinAgentCount);
+            roadProximityGrid?.Rebuild(agents, staggerMinAgentCount, playerTransform);
 
             frameIndex++;
         }

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianManager.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianManager.cs
@@ -38,9 +38,51 @@ namespace CityGenerator.Runtime
 
         [SerializeField] private float playerAvoidanceStrength = 6f;
 
+        [Tooltip("This manager's PedestrianRoadProximityGrid, on the same GameObject. Set by CityGeneratorPedestrianBuilder.AddManagerComponent. Rebuilt once per frame here so CarAgent can query nearby pedestrians without a SphereCast (item 8, stage 4).")]
+        [SerializeField] private PedestrianRoadProximityGrid roadProximityGrid;
+
         private readonly List<PedestrianAgent> agents = new();
-        private readonly Dictionary<Vector2Int, List<PedestrianAgent>> grid = new();
+        // Item 9: bucketed by index into `agents`, not by PedestrianAgent reference -- lets
+        // ApplyLocalSeparation dedupe pairs by comparing indices instead of doing a second,
+        // separate identity lookup.
+        private readonly Dictionary<Vector2Int, List<int>> grid = new();
+        // Only the 4 "forward" neighbour offsets (out of the full 3x3 = 9): visiting a cell pair
+        // from both directions would process every agent pair twice, once from each side, exactly
+        // the duplication item 9 removes. Picking one consistent half of the 8 neighbours (plus the
+        // cell's own bucket, handled separately) visits each unordered cell pair exactly once.
+        private static readonly Vector2Int[] ForwardNeighbourOffsets =
+        {
+            new(1, 0), new(1, 1), new(0, 1), new(-1, 1)
+        };
+        private Vector3[] separationPush = System.Array.Empty<Vector3>();
+        // Same staggering condition already computed once per agent in Update, reused by
+        // ApplyLocalSeparation so a pair where neither side is due for a recalculation this frame
+        // is skipped entirely instead of redoing the same push it already applied last frame.
+        private bool[] activeThisFrame = System.Array.Empty<bool>();
         private int frameIndex;
+
+        [Tooltip("This manager's own PedestrianNetwork, set by CityGeneratorPedestrianBuilder.AddManagerComponent -- only used to size PathBufferPool. Deliberately not a FindAnyObjectByType lookup: with multiple independent cities/networks in the same scene (see CLAUDE.md), that could resolve a different city's network and size the pool for the wrong graph.")]
+        [SerializeField] private PedestrianNetwork network;
+
+        // Item 9: shared pool of FindPath output buffers, lazily constructed on first use (Play
+        // mode only -- this field, like the pool itself, is never serialized). Every
+        // PedestrianAgent rents from this instead of keeping its own permanent nodeCount-sized array.
+        private PedestrianPathBufferPool pathBufferPool;
+        public PedestrianPathBufferPool PathBufferPool
+        {
+            get
+            {
+                if (pathBufferPool == null)
+                {
+                    // `network` is only unset for a standalone PedestrianManager auto-created by
+                    // PedestrianAgent.OnEnable's fallback (no generator involved) -- the generated
+                    // case always pre-wires it via CityGeneratorPedestrianBuilder.AddManagerComponent.
+                    PedestrianNetwork resolvedNetwork = network != null ? network : FindAnyObjectByType<PedestrianNetwork>();
+                    pathBufferPool = new PedestrianPathBufferPool(resolvedNetwork != null ? resolvedNetwork.NodeCount : 0);
+                }
+                return pathBufferPool;
+            }
+        }
 
         // Looked up lazily rather than once in Awake: the scene's Player instance is spawned by
         // CityGeneratorSceneBuilder after PedestrianManager already exists, so an eager lookup
@@ -68,6 +110,9 @@ namespace CityGenerator.Runtime
             Vector3 camPosition = cam != null ? cam.transform.position : Vector3.zero;
             float sqrStaggerDistance = staggerDistance * staggerDistance;
 
+            if (activeThisFrame.Length < agents.Count)
+                activeThisFrame = new bool[agents.Count];
+
             for (int i = 0; i < agents.Count; i++)
             {
                 PedestrianAgent agent = agents[i];
@@ -80,11 +125,14 @@ namespace CityGenerator.Runtime
                         runLogic = (frameIndex + i) % staggerFrames == 0;
                 }
 
+                activeThisFrame[i] = runLogic;
                 agent.Tick(dt, runLogic);
             }
 
             ApplyLocalSeparation(dt);
             ApplyPlayerAvoidance(dt);
+
+            roadProximityGrid?.Rebuild(agents, staggerMinAgentCount);
 
             frameIndex++;
         }
@@ -122,60 +170,75 @@ namespace CityGenerator.Runtime
             }
         }
 
+        /// <summary>
+        /// Item 9: each unordered agent pair is evaluated exactly once (instead of once per side,
+        /// which computed and applied the same push twice under slightly different floating-point
+        /// paths) and, when neither agent of a pair is due for a recalculation this frame (see
+        /// activeThisFrame/the same staggering condition Update already computed), the pair is
+        /// skipped entirely -- a stationary crowd far from the camera doesn't repeat the same
+        /// push-apart work every single frame.
+        /// </summary>
         private void ApplyLocalSeparation(float dt)
         {
             RebuildGrid();
 
+            if (separationPush.Length < agents.Count)
+                separationPush = new Vector3[agents.Count];
+            System.Array.Clear(separationPush, 0, agents.Count);
+
             float sqrSeparationRadius = separationRadius * separationRadius;
+
+            foreach (KeyValuePair<Vector2Int, List<int>> entry in grid)
+            {
+                Vector2Int cell = entry.Key;
+                List<int> bucket = entry.Value;
+
+                for (int a = 0; a < bucket.Count; a++)
+                {
+                    for (int b = a + 1; b < bucket.Count; b++)
+                        AccumulateSeparationPair(bucket[a], bucket[b], sqrSeparationRadius);
+                }
+
+                for (int n = 0; n < ForwardNeighbourOffsets.Length; n++)
+                {
+                    if (!grid.TryGetValue(cell + ForwardNeighbourOffsets[n], out List<int> neighbourBucket))
+                        continue;
+
+                    for (int a = 0; a < bucket.Count; a++)
+                    {
+                        for (int b = 0; b < neighbourBucket.Count; b++)
+                            AccumulateSeparationPair(bucket[a], neighbourBucket[b], sqrSeparationRadius);
+                    }
+                }
+            }
 
             for (int i = 0; i < agents.Count; i++)
             {
-                PedestrianAgent agent = agents[i];
-                Vector3 position = agent.transform.position;
-                Vector2Int cell = CellOf(position);
-                Vector3 push = Vector3.zero;
-
-                for (int dx = -1; dx <= 1; dx++)
-                {
-                    for (int dz = -1; dz <= 1; dz++)
-                    {
-                        if (!grid.TryGetValue(new Vector2Int(cell.x + dx, cell.y + dz), out List<PedestrianAgent> bucket))
-                        {
-                            continue;
-                        }
-
-                        for (int b = 0; b < bucket.Count; b++)
-                        {
-                            PedestrianAgent other = bucket[b];
-                            if (other == agent)
-                            {
-                                continue;
-                            }
-
-                            Vector3 offset = position - other.transform.position;
-                            offset.y = 0f;
-                            float sqrDistance = offset.sqrMagnitude;
-                            if (sqrDistance < 0.0001f || sqrDistance >= sqrSeparationRadius)
-                            {
-                                continue;
-                            }
-
-                            float distance = Mathf.Sqrt(sqrDistance);
-                            push += offset / distance * (1f - distance / separationRadius);
-                        }
-                    }
-                }
-
-                if (push.sqrMagnitude > 0.0001f)
-                {
-                    agent.transform.position += push * separationStrength * dt;
-                }
+                if (separationPush[i].sqrMagnitude > 0.0001f)
+                    agents[i].transform.position += separationPush[i] * separationStrength * dt;
             }
+        }
+
+        private void AccumulateSeparationPair(int i, int j, float sqrSeparationRadius)
+        {
+            if (!activeThisFrame[i] && !activeThisFrame[j])
+                return;
+
+            Vector3 offset = agents[i].transform.position - agents[j].transform.position;
+            offset.y = 0f;
+            float sqrDistance = offset.sqrMagnitude;
+            if (sqrDistance < 0.0001f || sqrDistance >= sqrSeparationRadius)
+                return;
+
+            float distance = Mathf.Sqrt(sqrDistance);
+            Vector3 push = offset / distance * (1f - distance / separationRadius);
+            separationPush[i] += push;
+            separationPush[j] -= push;
         }
 
         private void RebuildGrid()
         {
-            foreach (List<PedestrianAgent> bucket in grid.Values)
+            foreach (List<int> bucket in grid.Values)
             {
                 bucket.Clear();
             }
@@ -183,13 +246,13 @@ namespace CityGenerator.Runtime
             for (int i = 0; i < agents.Count; i++)
             {
                 Vector2Int cell = CellOf(agents[i].transform.position);
-                if (!grid.TryGetValue(cell, out List<PedestrianAgent> bucket))
+                if (!grid.TryGetValue(cell, out List<int> bucket))
                 {
-                    bucket = new List<PedestrianAgent>();
+                    bucket = new List<int>();
                     grid[cell] = bucket;
                 }
 
-                bucket.Add(agents[i]);
+                bucket.Add(i);
             }
         }
 

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianNetwork.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianNetwork.cs
@@ -91,6 +91,11 @@ namespace CityGenerator.Runtime
 
         public PedestrianManager Manager => manager;
 
+        [Tooltip("This network's PedestrianRoadProximityGrid, on the same GameObject as Manager. Set by CityGeneratorPedestrianBuilder.AddManagerComponent. CarAgent queries it for nearby pedestrians instead of SphereCasting once the pedestrian count justifies it.")]
+        [SerializeField] private PedestrianRoadProximityGrid roadProximity;
+
+        public PedestrianRoadProximityGrid RoadProximity => roadProximity;
+
         [Header("Obstacle pruning")]
         [Tooltip("Layers Physics.CheckSphere treats as obstacles. Set by CityGeneratorPedestrianBuilder to exclude the Pedestrian layer: without that, a pedestrian standing right on its own spawn node gets detected by this very check the moment PedestrianNetwork.Awake() rebuilds the graph in Play, wrongly marking that node (and any neighbour whose only route ran through it) Blocked.")]
         [SerializeField] private LayerMask obstacleMask = ~0;
@@ -121,8 +126,19 @@ namespace CityGenerator.Runtime
         // by every FindPath call without allocating — Unity's single-threaded main loop makes one
         // shared set safe across every agent that calls FindPath in turn.
         private int[] bfsQueue;
-        private int[] bfsParent;
         private bool[] bfsVisited;
+
+        // Connected components (item 9): parallel to `nodes`, recomputed every Build() by a flood
+        // fill over the just-built edges. Lets PlanNewDestination filter candidate destinations to
+        // the origin's own component before ever attempting a route, instead of discovering
+        // unreachability only after a failed FindPath -- the common case on a 1xN/Nx1 grid, whose
+        // blocks have no interior intersections to link their rings together (see CLAUDE.md).
+        private int[] nodeComponent;
+
+        // Short-lived BFS route cache (item 9): keyed by origin node, invalidated on every Build().
+        // Several pedestrians planning in the same short window of frames from nearby/identical
+        // origins reuse one shared cameFrom tree instead of each re-running its own BFS.
+        private readonly Dictionary<int, int[]> cameFromCache = new();
 
         public int NodeCount
         {
@@ -172,6 +188,14 @@ namespace CityGenerator.Runtime
         {
             nodes.Clear();
             poiDescriptorByNodeIndex.Clear();
+            cameFromCache.Clear();
+            // Null (not just cleared) while Build() runs its own internal AddNode calls (ring,
+            // crossing, ReinsertPointsOfInterest): AddNode only tries to keep nodeComponent in sync
+            // once it's non-null, so those calls are left alone and ComputeConnectedComponents
+            // below computes the array fresh, once, from the complete final node set. It only
+            // needs to stay in sync afterwards, for nodes AddNode-ed by the generator once Build()
+            // has already returned (plaza POIs; see RegisterPointOfInterest).
+            nodeComponent = null;
 
             if (trafficNetwork == null)
             {
@@ -209,7 +233,57 @@ namespace CityGenerator.Runtime
             ReinsertPointsOfInterest();
 
             RebuildBfsBuffers();
+            ComputeConnectedComponents();
             PrunePlacedObstacles();
+        }
+
+        /// <summary>
+        /// Flood fill over the just-built edges, assigning every node an index identifying which
+        /// connected component it belongs to. Independent of Blocked: components reflect graph
+        /// topology (the same thing FindPath's reachability ultimately depends on), not runtime
+        /// obstacle pruning.
+        /// </summary>
+        private void ComputeConnectedComponents()
+        {
+            nodeComponent = new int[nodes.Count];
+            for (int i = 0; i < nodeComponent.Length; i++)
+                nodeComponent[i] = -1;
+
+            var stack = new Stack<int>();
+            int currentComponent = 0;
+
+            for (int start = 0; start < nodes.Count; start++)
+            {
+                if (nodeComponent[start] != -1)
+                    continue;
+
+                stack.Push(start);
+                nodeComponent[start] = currentComponent;
+
+                while (stack.Count > 0)
+                {
+                    int current = stack.Pop();
+                    List<int> neighbours = nodes[current].Neighbours;
+                    for (int n = 0; n < neighbours.Count; n++)
+                    {
+                        int next = neighbours[n];
+                        if (nodeComponent[next] == -1)
+                        {
+                            nodeComponent[next] = currentComponent;
+                            stack.Push(next);
+                        }
+                    }
+                }
+
+                currentComponent++;
+            }
+        }
+
+        /// <summary>Which connected component <paramref name="nodeIndex"/> belongs to -- two nodes only have any chance of a path between them if this matches.</summary>
+        public int ComponentOf(int nodeIndex)
+        {
+            EnsureBuilt();
+            return nodeComponent[nodeIndex];
         }
 
         /// <summary>
@@ -392,7 +466,20 @@ namespace CityGenerator.Runtime
                 LookAt = lookAt,
                 Neighbours = new List<int>()
             });
-            return nodes.Count - 1;
+            int index = nodes.Count - 1;
+
+            // Only once Build() has already computed the array once (nodeComponent is null while
+            // Build() runs its own internal AddNode calls -- see Build()): keeps it in sync for a
+            // node AddNode-ed afterwards (a plaza POI), so PickRandomDestination never indexes past
+            // its end. Starts unassigned (-1); RegisterPointOfInterest fills it in from whatever
+            // it connects to.
+            if (nodeComponent != null)
+            {
+                System.Array.Resize(ref nodeComponent, nodes.Count);
+                nodeComponent[index] = -1;
+            }
+
+            return index;
         }
 
         /// <summary>Adds an undirected edge between two existing nodes.</summary>
@@ -431,6 +518,11 @@ namespace CityGenerator.Runtime
                 ConnectPointOfInterest(nodeIndex, connectedNodeIndex);
             }
 
+            // A cached cameFrom tree from before this node/edge existed wouldn't know how to reach
+            // it. Cheap to drop entirely rather than track exactly which cached origins are now
+            // stale -- registration only happens a handful of times per generation run.
+            cameFromCache.Clear();
+
             return nodeIndex;
         }
 
@@ -446,6 +538,18 @@ namespace CityGenerator.Runtime
             Connect(a, b);
             AppendPoiConnection(a, b);
             AppendPoiConnection(b, a);
+
+            // Keeps a POI node's component in sync with whatever it just connected to (see AddNode):
+            // it starts at -1 (unassigned) and only ever needs to inherit once, from either side --
+            // covers both a POI connecting to an existing Ring node and a POI-to-POI edge (e.g. a
+            // plaza centerpiece's loop), as long as at least one side already has a real component.
+            if (nodeComponent != null)
+            {
+                if (nodeComponent[a] == -1 && nodeComponent[b] != -1)
+                    nodeComponent[a] = nodeComponent[b];
+                else if (nodeComponent[b] == -1 && nodeComponent[a] != -1)
+                    nodeComponent[b] = nodeComponent[a];
+            }
         }
 
         private void AppendPoiConnection(int nodeIndex, int otherIndex)
@@ -536,19 +640,29 @@ namespace CityGenerator.Runtime
             return trafficNetwork.AxisState(node.Intersection, node.CrossingAxisIsX) == TrafficLightState.Red;
         }
 
-        /// <summary>Picks a random non-blocked Ring or PointOfInterest node — the only kinds valid as a final destination.</summary>
-        public int PickRandomDestination()
+        /// <summary>
+        /// Picks a random non-blocked Ring or PointOfInterest node — the only kinds valid as a
+        /// final destination. When <paramref name="requiredComponent"/> is non-negative (item 9),
+        /// only considers nodes in that connected component: on a grid with isolated block rings
+        /// (e.g. gridWidth == 1 or gridHeight == 1, see CLAUDE.md), this stops PlanNewDestination
+        /// from repeatedly drawing candidates FindPath could never reach in the first place.
+        /// </summary>
+        public int PickRandomDestination(int requiredComponent = -1)
         {
             EnsureBuilt();
             int attempts = nodes.Count * 2;
             for (int attempt = 0; attempt < attempts; attempt++)
             {
                 int candidate = Random.Range(0, nodes.Count);
-                PedestrianNodeKind kind = nodes[candidate].Kind;
-                if (!nodes[candidate].Blocked && (kind == PedestrianNodeKind.Ring || kind == PedestrianNodeKind.PointOfInterest))
-                {
-                    return candidate;
-                }
+                PedestrianNode node = nodes[candidate];
+                if (node.Blocked)
+                    continue;
+                if (node.Kind != PedestrianNodeKind.Ring && node.Kind != PedestrianNodeKind.PointOfInterest)
+                    continue;
+                if (requiredComponent >= 0 && nodeComponent[candidate] != requiredComponent)
+                    continue;
+
+                return candidate;
             }
 
             return -1;
@@ -557,8 +671,14 @@ namespace CityGenerator.Runtime
         /// <summary>
         /// Breadth-first shortest path from `from` to `to` (fewest hops; every edge is unweighted).
         /// Writes node indices (from -> to inclusive) into the caller-supplied outPath buffer and
-        /// returns how many were written, or 0 if unreachable. Uses only the pre-allocated BFS
-        /// scratch buffers — no allocation per call.
+        /// returns how many were written, or 0 if unreachable.
+        ///
+        /// Item 9: the full single-source `cameFrom` tree from `from` is cached (see
+        /// <see cref="cameFromCache"/>) rather than only walking until `to` is found, so several
+        /// FindPath calls sharing the same `from` within one Build() window (PlanNewDestination
+        /// tries up to 8 candidate destinations per call, always from the current node) reuse one
+        /// BFS instead of re-running it per destination. The BFS itself is still zero-allocation
+        /// per call; only the first call for a given, not-yet-cached `from` allocates its tree.
         /// </summary>
         public int FindPath(int from, int to, int[] outPath)
         {
@@ -568,51 +688,17 @@ namespace CityGenerator.Runtime
                 return 0;
             }
 
-            // AddNode may have grown the graph (e.g. points of interest registered after Build())
-            // since the buffers were last sized.
-            if (bfsQueue == null || bfsQueue.Length != nodes.Count)
-            {
-                RebuildBfsBuffers();
-            }
-
             if (from == to)
             {
                 outPath[0] = from;
                 return 1;
             }
 
-            System.Array.Clear(bfsVisited, 0, bfsVisited.Length);
-            int head = 0, tail = 0;
-            bfsQueue[tail++] = from;
-            bfsVisited[from] = true;
-            bfsParent[from] = -1;
+            int[] cameFrom = GetOrComputeCameFrom(from);
 
-            bool found = false;
-            while (head < tail)
-            {
-                int current = bfsQueue[head++];
-                if (current == to)
-                {
-                    found = true;
-                    break;
-                }
-
-                List<int> neighbours = nodes[current].Neighbours;
-                for (int n = 0; n < neighbours.Count; n++)
-                {
-                    int next = neighbours[n];
-                    if (bfsVisited[next] || nodes[next].Blocked)
-                    {
-                        continue;
-                    }
-
-                    bfsVisited[next] = true;
-                    bfsParent[next] = current;
-                    bfsQueue[tail++] = next;
-                }
-            }
-
-            if (!found)
+            // -2 = never visited by this origin's BFS (unreachable); -1 is reserved for `from`
+            // itself, which can't be `to` here (handled above).
+            if (cameFrom[to] == -2)
             {
                 return 0;
             }
@@ -622,7 +708,7 @@ namespace CityGenerator.Runtime
             while (node != -1)
             {
                 length++;
-                node = bfsParent[node];
+                node = cameFrom[node];
             }
 
             if (length > outPath.Length)
@@ -636,16 +722,60 @@ namespace CityGenerator.Runtime
             while (node != -1 && writeIndex >= 0)
             {
                 outPath[writeIndex--] = node;
-                node = bfsParent[node];
+                node = cameFrom[node];
             }
 
             return length;
         }
 
+        private int[] GetOrComputeCameFrom(int from)
+        {
+            if (cameFromCache.TryGetValue(from, out int[] cached))
+            {
+                return cached;
+            }
+
+            // AddNode may have grown the graph (e.g. points of interest registered after Build())
+            // since the scratch buffers were last sized.
+            if (bfsQueue == null || bfsQueue.Length != nodes.Count)
+            {
+                RebuildBfsBuffers();
+            }
+
+            var cameFrom = new int[nodes.Count];
+            System.Array.Fill(cameFrom, -2);
+
+            System.Array.Clear(bfsVisited, 0, bfsVisited.Length);
+            int head = 0, tail = 0;
+            bfsQueue[tail++] = from;
+            bfsVisited[from] = true;
+            cameFrom[from] = -1;
+
+            while (head < tail)
+            {
+                int current = bfsQueue[head++];
+                List<int> neighbours = nodes[current].Neighbours;
+                for (int n = 0; n < neighbours.Count; n++)
+                {
+                    int next = neighbours[n];
+                    if (bfsVisited[next] || nodes[next].Blocked)
+                    {
+                        continue;
+                    }
+
+                    bfsVisited[next] = true;
+                    cameFrom[next] = current;
+                    bfsQueue[tail++] = next;
+                }
+            }
+
+            cameFromCache[from] = cameFrom;
+            return cameFrom;
+        }
+
         private void RebuildBfsBuffers()
         {
             bfsQueue = new int[nodes.Count];
-            bfsParent = new int[nodes.Count];
             bfsVisited = new bool[nodes.Count];
         }
 

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianPathBufferPool.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianPathBufferPool.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace CityGenerator.Runtime
+{
+    /// <summary>
+    /// Shared pool of <see cref="PedestrianNetwork.FindPath"/> output buffers, each sized to the
+    /// graph's node count -- the worst case a path can ever be. Before item 9's staggered initial
+    /// planning, every <see cref="PedestrianAgent"/> kept one such array alive for its whole
+    /// lifetime (O(pedestrians x nodes) memory) even though it only actually needs the full-size
+    /// buffer for the brief moment FindPath is filling it; the agent's own persistent state only
+    /// ever needs however many nodes its *current* path actually has. A small pool, borrowed during
+    /// planning and returned immediately after the used portion is copied out, replaces that.
+    /// </summary>
+    public sealed class PedestrianPathBufferPool
+    {
+        private readonly int nodeCount;
+        private readonly Stack<int[]> buffers = new();
+
+        public PedestrianPathBufferPool(int nodeCount)
+        {
+            this.nodeCount = nodeCount;
+        }
+
+        public int[] Rent() => buffers.Count > 0 ? buffers.Pop() : new int[nodeCount];
+
+        public void Return(int[] buffer)
+        {
+            if (buffer != null && buffer.Length == nodeCount)
+                buffers.Push(buffer);
+        }
+    }
+}

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianPathBufferPool.cs.meta
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianPathBufferPool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f6e7dfff87b8f4f42a0bbd7c4c43ad42

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianRoadProximityGrid.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianRoadProximityGrid.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CityGenerator.Runtime
+{
+    /// <summary>
+    /// Spatial grid of pedestrian positions, rebuilt once per frame by <see cref="PedestrianManager"/>
+    /// (same pattern as its own local-separation grid), so <see cref="CarAgent"/> can find nearby
+    /// pedestrians without a <c>SphereCastNonAlloc</c> once the pedestrian count justifies it (item
+    /// 8, stage 4). Only ever an additional way to answer the same question the sensor already
+    /// answers -- see <see cref="HasEnoughAgents"/> and CarAgent's fallback to its existing sensor.
+    /// </summary>
+    public sealed class PedestrianRoadProximityGrid : MonoBehaviour
+    {
+        [SerializeField] private float cellSize = 10f;
+
+        private readonly Dictionary<(int x, int z), List<PedestrianAgent>> cells = new();
+
+        /// <summary>
+        /// Set by the last <see cref="Rebuild"/> call: true once there are more pedestrians than
+        /// the threshold that makes querying this grid worth it instead of a fresh SphereCast --
+        /// mirrors PedestrianManager's own staggerMinAgentCount.
+        /// </summary>
+        public bool HasEnoughAgents { get; private set; }
+
+        /// <summary>Called once per frame by PedestrianManager, after ticking every agent.</summary>
+        public void Rebuild(IReadOnlyList<PedestrianAgent> agents, int minAgentCountToUse)
+        {
+            foreach (List<PedestrianAgent> bucket in cells.Values)
+                bucket.Clear();
+
+            for (int i = 0; i < agents.Count; i++)
+            {
+                var cell = CellOf(agents[i].transform.position);
+                if (!cells.TryGetValue(cell, out List<PedestrianAgent> bucket))
+                {
+                    bucket = new List<PedestrianAgent>();
+                    cells[cell] = bucket;
+                }
+                bucket.Add(agents[i]);
+            }
+
+            HasEnoughAgents = agents.Count > minAgentCountToUse;
+        }
+
+        /// <summary>Appends every pedestrian within <paramref name="radius"/> of <paramref name="position"/> to <paramref name="results"/> (cleared first).</summary>
+        public void QueryNear(Vector3 position, float radius, List<PedestrianAgent> results)
+        {
+            results.Clear();
+            (int cx, int cz) = CellOf(position);
+            int spread = Mathf.CeilToInt(radius / cellSize);
+            float sqrRadius = radius * radius;
+
+            for (int dx = -spread; dx <= spread; dx++)
+            {
+                for (int dz = -spread; dz <= spread; dz++)
+                {
+                    if (!cells.TryGetValue((cx + dx, cz + dz), out List<PedestrianAgent> bucket))
+                        continue;
+
+                    for (int i = 0; i < bucket.Count; i++)
+                    {
+                        PedestrianAgent agent = bucket[i];
+                        if (agent != null && (agent.transform.position - position).sqrMagnitude <= sqrRadius)
+                            results.Add(agent);
+                    }
+                }
+            }
+        }
+
+        private (int x, int z) CellOf(Vector3 position)
+            => (Mathf.FloorToInt(position.x / cellSize), Mathf.FloorToInt(position.z / cellSize));
+    }
+}

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianRoadProximityGrid.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianRoadProximityGrid.cs
@@ -16,6 +16,13 @@ namespace CityGenerator.Runtime
 
         private readonly Dictionary<(int x, int z), List<PedestrianAgent>> cells = new();
 
+        // The player is on the same Pedestrian layer as every NPC (CityGeneratorSceneBuilder puts
+        // it there regardless of Include Pedestrians -- see CLAUDE.md) and CarAgent's SphereCast
+        // sensor always detected it, but the player is never itself a PedestrianAgent, so it can
+        // never appear in `cells` above. Tracked separately and reported by TryGetPlayerPosition so
+        // CarAgent's grid path can still brake for the player once this grid takes over.
+        private Vector3? playerPosition;
+
         /// <summary>
         /// Set by the last <see cref="Rebuild"/> call: true once there are more pedestrians than
         /// the threshold that makes querying this grid worth it instead of a fresh SphereCast --
@@ -24,7 +31,7 @@ namespace CityGenerator.Runtime
         public bool HasEnoughAgents { get; private set; }
 
         /// <summary>Called once per frame by PedestrianManager, after ticking every agent.</summary>
-        public void Rebuild(IReadOnlyList<PedestrianAgent> agents, int minAgentCountToUse)
+        public void Rebuild(IReadOnlyList<PedestrianAgent> agents, int minAgentCountToUse, Transform player)
         {
             foreach (List<PedestrianAgent> bucket in cells.Values)
                 bucket.Clear();
@@ -40,7 +47,21 @@ namespace CityGenerator.Runtime
                 bucket.Add(agents[i]);
             }
 
+            playerPosition = player != null ? player.position : (Vector3?)null;
             HasEnoughAgents = agents.Count > minAgentCountToUse;
+        }
+
+        /// <summary>True if the player exists in this scene, with its current position.</summary>
+        public bool TryGetPlayerPosition(out Vector3 position)
+        {
+            if (playerPosition.HasValue)
+            {
+                position = playerPosition.Value;
+                return true;
+            }
+
+            position = default;
+            return false;
         }
 
         /// <summary>Appends every pedestrian within <paramref name="radius"/> of <paramref name="position"/> to <paramref name="results"/> (cleared first).</summary>

--- a/Packages/com.santiandrade.citygenerator/Runtime/PedestrianRoadProximityGrid.cs.meta
+++ b/Packages/com.santiandrade.citygenerator/Runtime/PedestrianRoadProximityGrid.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9010dfea83a895e45a9aedf9b4f5ae44

--- a/Packages/com.santiandrade.citygenerator/Runtime/TrafficLaneOccupancy.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/TrafficLaneOccupancy.cs
@@ -5,11 +5,11 @@ namespace CityGenerator.Runtime
 {
     /// <summary>
     /// Resolves only the "is there a CarAgent immediately ahead on the same lane segment?" case
-    /// without a <c>SphereCast</c>: a per-segment occupancy list, ordered by
-    /// <see cref="CarAgent.DistanceTravelled"/>, that <see cref="CarAgent"/> consults first before
-    /// falling back to its existing forward sensor for pedestrians, crossings and arbitrary
-    /// obstacles (see the four "load-bearing" sensor rules in CLAUDE.md — this only ever replaces
-    /// the cheap, common case, never the sensor itself).
+    /// without a physics query: a per-segment occupancy list, ordered by forward projection towards
+    /// the querying car's own target node, that <see cref="CarAgent"/> consults first before
+    /// falling back to its existing sensor for pedestrians, crossings and arbitrary obstacles (see
+    /// the four "load-bearing" sensor rules in CLAUDE.md — this only ever replaces the cheap,
+    /// common case, never the sensor itself).
     /// </summary>
     public sealed class TrafficLaneOccupancy : MonoBehaviour
     {
@@ -38,18 +38,30 @@ namespace CityGenerator.Runtime
         }
 
         /// <summary>
-        /// True if another CarAgent on the same segment, strictly ahead of <paramref name="agent"/>
-        /// by <see cref="CarAgent.DistanceTravelled"/>, was found -- false means "no answer from
-        /// this index", not "the lane is clear": the caller should fall back to its own sensor
-        /// (an empty/absent segment entry, a car at the very end of its segment about to turn, or a
-        /// crossing are all cases this index doesn't attempt to resolve).
+        /// True if another CarAgent on the same segment, geometrically ahead of
+        /// <paramref name="agent"/>, was found -- false means "no answer from this index", not "the
+        /// lane is clear": the caller should fall back to its own sensor (an empty/absent segment
+        /// entry, a car at the very end of its segment about to turn, or a crossing are all cases
+        /// this index doesn't attempt to resolve).
+        ///
+        /// Ordered by forward projection along <paramref name="forward"/> -- the direction towards
+        /// <paramref name="agent"/>'s own target node, not its live transform.forward, because
+        /// mid-corner the two can disagree enough to flip the sign (see the comment on the caller,
+        /// <see cref="CarAgent.VehicleAheadClearance"/>) -- not by <see cref="CarAgent.DistanceTravelled"/>
+        /// as this used to be: DistanceTravelled is a lifetime total, and two cars sharing a segment
+        /// can have wildly different totals (one spawned recently, one mid-way through its Nth lap)
+        /// with no relation to which one is physically closer to the stop line. Comparing totals
+        /// could not just misorder a queue -- it could report "no one ahead" for a car with a lower
+        /// total sitting right behind one with a higher total, skipping the sensor fallback's own
+        /// detection entirely and letting it drive straight through the car actually ahead of it.
         /// </summary>
-        public bool TryGetCarAhead(CarAgent agent, int fromNode, int toNode, out CarAgent ahead)
+        public bool TryGetCarAhead(CarAgent agent, int fromNode, int toNode, Vector3 forward, out CarAgent ahead)
         {
             ahead = null;
             if (!segmentOccupants.TryGetValue((fromNode, toNode), out List<CarAgent> occupants))
                 return false;
 
+            Vector3 agentPosition = agent.transform.position;
             float bestDistance = float.MaxValue;
             for (int i = 0; i < occupants.Count; i++)
             {
@@ -57,10 +69,10 @@ namespace CityGenerator.Runtime
                 if (other == agent || other == null)
                     continue;
 
-                float delta = other.DistanceTravelled - agent.DistanceTravelled;
-                if (delta > 0f && delta < bestDistance)
+                float along = Vector3.Dot(other.transform.position - agentPosition, forward);
+                if (along > 0f && along < bestDistance)
                 {
-                    bestDistance = delta;
+                    bestDistance = along;
                     ahead = other;
                 }
             }

--- a/Packages/com.santiandrade.citygenerator/Runtime/TrafficLaneOccupancy.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/TrafficLaneOccupancy.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CityGenerator.Runtime
+{
+    /// <summary>
+    /// Resolves only the "is there a CarAgent immediately ahead on the same lane segment?" case
+    /// without a <c>SphereCast</c>: a per-segment occupancy list, ordered by
+    /// <see cref="CarAgent.DistanceTravelled"/>, that <see cref="CarAgent"/> consults first before
+    /// falling back to its existing forward sensor for pedestrians, crossings and arbitrary
+    /// obstacles (see the four "load-bearing" sensor rules in CLAUDE.md — this only ever replaces
+    /// the cheap, common case, never the sensor itself).
+    /// </summary>
+    public sealed class TrafficLaneOccupancy : MonoBehaviour
+    {
+        // Key = directed edge (fromNode, toNode) of TrafficNetwork's graph -- a car "occupies" the
+        // segment it is currently driving towards (its targetNode) coming from the node it last
+        // departed.
+        private readonly Dictionary<(int from, int to), List<CarAgent>> segmentOccupants = new();
+
+        public void Enter(CarAgent agent, int fromNode, int toNode)
+        {
+            var key = (fromNode, toNode);
+            if (!segmentOccupants.TryGetValue(key, out List<CarAgent> occupants))
+            {
+                occupants = new List<CarAgent>();
+                segmentOccupants[key] = occupants;
+            }
+
+            if (!occupants.Contains(agent))
+                occupants.Add(agent);
+        }
+
+        public void Leave(CarAgent agent, int fromNode, int toNode)
+        {
+            if (segmentOccupants.TryGetValue((fromNode, toNode), out List<CarAgent> occupants))
+                occupants.Remove(agent);
+        }
+
+        /// <summary>
+        /// True if another CarAgent on the same segment, strictly ahead of <paramref name="agent"/>
+        /// by <see cref="CarAgent.DistanceTravelled"/>, was found -- false means "no answer from
+        /// this index", not "the lane is clear": the caller should fall back to its own sensor
+        /// (an empty/absent segment entry, a car at the very end of its segment about to turn, or a
+        /// crossing are all cases this index doesn't attempt to resolve).
+        /// </summary>
+        public bool TryGetCarAhead(CarAgent agent, int fromNode, int toNode, out CarAgent ahead)
+        {
+            ahead = null;
+            if (!segmentOccupants.TryGetValue((fromNode, toNode), out List<CarAgent> occupants))
+                return false;
+
+            float bestDistance = float.MaxValue;
+            for (int i = 0; i < occupants.Count; i++)
+            {
+                CarAgent other = occupants[i];
+                if (other == agent || other == null)
+                    continue;
+
+                float delta = other.DistanceTravelled - agent.DistanceTravelled;
+                if (delta > 0f && delta < bestDistance)
+                {
+                    bestDistance = delta;
+                    ahead = other;
+                }
+            }
+
+            return ahead != null;
+        }
+    }
+}

--- a/Packages/com.santiandrade.citygenerator/Runtime/TrafficLaneOccupancy.cs.meta
+++ b/Packages/com.santiandrade.citygenerator/Runtime/TrafficLaneOccupancy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7350ec2ec1bd1db4a9a9549e75bb64eb

--- a/Packages/com.santiandrade.citygenerator/Runtime/TrafficManager.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/TrafficManager.cs
@@ -34,6 +34,9 @@ namespace CityGenerator.Runtime
 
         private void Update()
         {
+            if (agents.Count == 0)
+                return;
+
             float dt = Time.deltaTime;
             bool staggeringActive = agents.Count > staggerMinAgentCount && staggerFrames > 1;
             Camera cam = staggeringActive ? Camera.main : null;
@@ -53,6 +56,18 @@ namespace CityGenerator.Runtime
 
                 agent.Tick(dt, runSensor);
             }
+
+            // CarAgent moves every car by writing transform.position directly (no Rigidbody), and
+            // its forward sensor queries the physics scene in the same frame. With
+            // DynamicsManager.m_AutoSyncTransforms off (the project default), the physics scene
+            // only sees those moves at the next FixedUpdate, so at 60+ FPS the sensor reads
+            // positions up to one frame stale — enough error for cars to miss each other on
+            // corners. One sync here, after every CarAgent has ticked, is cheaper than turning
+            // auto-sync back on (which would sync on every single query instead of once per
+            // frame). Only called when there's at least one agent (the early return above), and
+            // moved here from TrafficNetwork.LateUpdate so a scene with a TrafficNetwork but zero
+            // registered CarAgents never pays for it at all.
+            Physics.SyncTransforms();
 
             frameIndex++;
         }

--- a/Packages/com.santiandrade.citygenerator/Runtime/TrafficNetwork.cs
+++ b/Packages/com.santiandrade.citygenerator/Runtime/TrafficNetwork.cs
@@ -64,6 +64,11 @@ namespace CityGenerator.Runtime
 
         public TrafficManager Manager => manager;
 
+        [Tooltip("This network's TrafficLaneOccupancy, on the same GameObject as Manager. Set by CityGeneratorTrafficBuilder.AddManagerComponent. CarAgent consults it first for the 'car ahead in the same lane segment' case before falling back to its SphereCast sensor.")]
+        [SerializeField] private TrafficLaneOccupancy laneOccupancy;
+
+        public TrafficLaneOccupancy LaneOccupancy => laneOccupancy;
+
         [Tooltip("Time after which an unsignalled crossing's priority is released if its owner hasn't passed.")]
         [SerializeField] private float reservationTimeout = 4f;
 
@@ -112,19 +117,6 @@ namespace CityGenerator.Runtime
         private void Awake()
         {
             Build();
-        }
-
-        // CarAgent moves every car by writing transform.position directly (no Rigidbody), and its
-        // forward sensor queries the physics scene in the same frame. With
-        // DynamicsManager.m_AutoSyncTransforms off (the project default), the physics scene only
-        // sees those moves at the next FixedUpdate, so at 60+ FPS the sensor reads positions up to
-        // one frame stale — enough error for cars to miss each other on corners. One sync here,
-        // after every CarAgent's Update has run, is cheaper than turning auto-sync back on (which
-        // would sync on every single query instead of once per frame) and, being in the tool's own
-        // code rather than a project setting, travels with the package if it's copied elsewhere.
-        private void LateUpdate()
-        {
-            Physics.SyncTransforms();
         }
 
         /// <summary>

--- a/Packages/com.santiandrade.citygenerator/package.json
+++ b/Packages/com.santiandrade.citygenerator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.santiandrade.citygenerator",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "displayName": "City Generator",
   "description": "Editor tool that procedurally generates a full city — roads, sidewalks, markings, buildings, plazas, street furniture, traffic lights and autonomous traffic — into a new or existing scene.",
   "unity": "6000.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -11,6 +11,7 @@
     "com.unity.probuilder": "6.1.2",
     "com.unity.render-pipelines.universal": "17.5.0",
     "com.unity.test-framework": "1.7.0",
+    "com.unity.test-framework.performance": "3.1.0",
     "com.unity.timeline": "1.8.12",
     "com.unity.ugui": "2.5.0",
     "com.unity.visualscripting": "1.9.12",

--- a/specs/05-performance-and-tests.md
+++ b/specs/05-performance-and-tests.md
@@ -1,0 +1,280 @@
+# SPEC 05 — Rendimiento y suite de tests (informe técnico 2026-08-25)
+
+> **Estado:** Implementado
+> **Depende de:** SPEC 01 (City Generator Tool), SPEC 02 (Unity Package Distribution), SPEC 03 (Red peatonal), SPEC 04 (Correcciones críticas y arquitectónicas)
+> **Fecha:** 2026-08-25
+> **Objetivo:** Añadir la suite de tests EditMode/PlayMode/Performance que faltaba, medir un baseline real de generación y de tráfico/peatones en runtime, y usar esas mediciones para sustituir el solapamiento O(n²) de colocación por un índice espacial, reducir el coste físico del tráfico (`SyncTransforms`, sensores) y escalar el pathfinding/separación peatonal — siguiendo el orden "medir antes de optimizar" que el propio informe técnico recomienda y que el SPEC 04 dejó reservado explícitamente para esta ronda.
+
+## Por qué existe esta spec
+
+`docs/technical-review-2026-08-25.md` agrupa 19 mejoras priorizadas. El SPEC 04 abordó el bloque crítico completo más los ítems de prioridad alta que eran correcciones arquitectónicas puras (framerate global, validación de inputs, tooling interno, singletons de managers, autoridad del Input System), dejando explícitamente para "un SPEC 05 posterior" los ítems 6 (suite de tests), 7 (índice espacial de solapamiento), 8 (coste físico del tráfico) y 9 (pathfinding y separación peatonal) — siguiendo la recomendación del propio informe de no optimizar sin medir antes. Este spec es ese SPEC 05.
+
+Los ítems de prioridad media/baja sobre contenido demo y documentación (12, 14, 15, 17, 18, 19) quedan fuera, para specs futuros aún sin numerar, por no tener dependencia con el trabajo de rendimiento de este spec.
+
+## Scope
+
+**Dentro:**
+
+- **Ítem 6 — Suite de tests EditMode/PlayMode/Performance.**
+  - **`Assets/Tests/EditMode/` (nuevo, fuera del package)** — tests de: `CityGeneratorGrid` (bloques, plazas), `CityGeneratorDistributionUtility` (reparto de porcentajes), `CityGeneratorValidator`/`ValidateDetailed` (incluye los 7 huecos ya cubiertos por SPEC 04), pesos de ruta (`RouteWeight`/`Ring`), `PedestrianNetwork.FindPath` (BFS), persistencia de POI (`PointOfInterestDescriptor` sobrevive a `Build()`), y determinismo (misma semilla ⇒ mismo resultado).
+  - **`Assets/Tests/PlayMode/` (nuevo)** — tests de: ciclo de `TrafficLightIntersection` (fases verde/ámbar/rojo), cruce peatonal (`CanCross` solo en rojo), registro/desregistro de agentes en `TrafficManager`/`PedestrianManager` (incluye reactivación tras `SetActive`), dos ciudades generadas en la misma escena con managers independientes, y un vehículo/peatón de prueba con collider solo en un hijo (verificación automatizada de lo que hoy es manual en SPEC 04).
+  - **`Assets/Tests/EditMode/Generation/` (nuevo)** — generación completa con semilla fija en rejillas 1×3, 5×5 y 10×10, comprobando ausencia de excepciones y invariantes básicos (número de bloques, de edificios colocados, de nodos de red).
+  - **`Assets/Tests/Performance/` (nuevo)** — usando `com.unity.test-framework.performance` (añadido al `manifest.json` del proyecto, no al `package.json` del package instalable, ya que los tests viven fuera de él): tiempo de generación por tamaño de rejilla, `GC Alloc` de generación y de un frame en runtime con tráfico/peatones activos, coste de `Physics.SyncTransforms`, coste de `TrafficManager.Update`/`PedestrianManager.Update`, y memoria aproximada de la escena generada.
+  - Estos tests son la base de referencia ("baseline") que se mide antes de tocar nada de los ítems 7-9, y vuelven a ejecutarse después de cada uno para registrar el efecto real.
+
+- **Ítem 7 — Índice espacial para solapamientos.**
+  - **`Editor/CityGeneratorSpatialHash.cs` (nuevo)** — hash espacial uniforme, tamaño de celda derivado del tamaño de bloque de `CityGeneratorConstants`. Al insertar un obstáculo se registran las celdas de su `Rect`; al probar un candidato se consultan solo sus celdas y las vecinas.
+  - **`Editor/CityGeneratorPlacementEngine.cs`** — sustituye la comparación lineal contra la lista completa de obstáculos por una consulta al hash espacial. La lista `obstacles` que hoy se pasa entre categorías (ver CLAUDE.md) se mantiene como fuente de verdad; el hash es una estructura auxiliar de índice sobre ella, no la reemplaza.
+
+- **Ítem 8 — Coste físico del tráfico (las 4 etapas).**
+  - **Etapa 1 — `Runtime/TrafficNetwork.cs`** — `Physics.SyncTransforms()` solo se llama cuando `TrafficManager` tiene al menos un agente registrado.
+  - **Etapa 2 — `Runtime/TrafficManager.cs`** — la llamada a `SyncTransforms` se mueve del grafo (`TrafficNetwork`) al manager, después de ticar todos los agentes del frame.
+  - **Etapa 3 — `Runtime/TrafficLaneOccupancy.cs` (nuevo)** — índice de ocupación por carril/segmento que resuelve **solo** el caso "hay un `CarAgent` inmediatamente delante en el mismo tramo": `CarAgent` lo consulta primero y, si no da resultado (carril libre, fin de tramo, cruce), recurre al `SphereCastNonAlloc` existente como hoy para peatones, cruces y obstáculos arbitrarios. El sensor de peatones (`pedestrianMask`) no se toca en esta etapa.
+  - **Etapa 4 — `Runtime/PedestrianRoadProximityGrid.cs` (nuevo)** — rejilla espacial compartida (mismo patrón que la separación de `PedestrianManager`) para que `CarAgent` consulte peatones cercanos a la calzada sin `SphereCast`, usada como optimización adicional del sensor de peatones cuando el número de peatones supera `staggerMinAgentCount`.
+
+- **Ítem 9 — Pathfinding y separación peatonal (todas las propuestas).**
+  - **`Runtime/PedestrianNetwork.cs`** — cálculo de componentes conexas tras `Build()` (recalculado junto con anillos/cruces/POI); `PlanNewDestination` filtra candidatos a la componente conexa del origen antes de intentar rutas, evitando BFS contra nodos inalcanzables.
+  - **`Runtime/PedestrianManager.cs`** — la planificación inicial de destino (hoy concentrada en `Start` de cada agente) se reparte en varios frames tras el spawn, escalonada por índice de agente.
+  - **`Runtime/PedestrianNetwork.cs`** — caché ligera de rutas/árboles BFS reutilizable por nodo de origen dentro de la misma ventana de frames, invalidada en cada `Build()`.
+  - **`Runtime/PedestrianAgent.cs`** — los buffers usados por `FindPath` dejan de reservarse por agente de forma permanente (pooling/reutilización compartida), ya que la BFS en sí ya es zero-allocation por diseño de SPEC 03; esto ataca el pico de memoria O(peatones × nodos) al entrar en Play.
+  - **`Runtime/PedestrianManager.cs`** — en la pasada de separación, cada pareja de agentes cercanos se procesa una sola vez (no dos, una por cada lado); la frecuencia de recálculo de separación para agentes lejos de cámara se reduce siguiendo el mismo patrón de staggering ya usado para las decisiones de sensor.
+
+- **Medición.** Antes de tocar el ítem 7: ejecutar la suite de Performance en 1×3/5×5/10×10 y registrar los números en el spec (sección de resultados) o en la descripción del PR. Antes de tocar los ítems 8-9: generar una ciudad con 60/150/300 vehículos y peatones y repetir la medición. Después de cada ítem: repetir la medición correspondiente y anotar el delta.
+
+**Fuera de alcance:**
+
+- Ítems 12, 14, 15, 17, 18 y 19 (contenido demo, LOD, chunking de marcas viales, división de `CityGeneratorWindow`, documentación desactualizada) — specs futuros aún sin numerar, sin dependencia con el trabajo de rendimiento de este spec.
+- ECS/DOTS, object pooling de GameObjects, combinar toda la señalización en una malla única, activar GPU instancing de forma indiscriminada — descartados explícitamente por el informe para el estado actual del proyecto.
+- Cualquier cambio al comportamiento o resultado visual de la generación: los ítems 7-9 son optimizaciones internas: mismas reglas de colocación, mismo grafo de tráfico/peatones, mismo comportamiento observable de agentes.
+- Umbrales numéricos de rendimiento como criterio de aceptación bloqueante (se registran como datos informativos, no como gate).
+- Integración en un pipeline de CI (el proyecto no tiene uno; los tests y benchmarks se ejecutan manualmente desde el Test Runner de Unity).
+- Publicar una nueva versión del package (bump de `version`/tag) — paso posterior con `Tools > City Generator > Release`.
+
+## Modelo de datos
+
+Ítem 6 no introduce estructuras nuevas (son tests contra las clases ya existentes). Ítem 8, etapas 1-2, tampoco (son cambios de dónde/cuándo se llama a `Physics.SyncTransforms()`, no de datos).
+
+```csharp
+// Editor/CityGeneratorSpatialHash.cs (nuevo) — Ítem 7
+// Auxiliar sobre la lista `obstacles` ya existente: no la sustituye, la indexa.
+internal sealed class CityGeneratorSpatialHash
+{
+    private readonly float cellSize; // derivado de CityGeneratorConstants (tamaño de bloque)
+    private readonly Dictionary<(int x, int z), List<Rect>> cells = new();
+
+    public CityGeneratorSpatialHash(float cellSize) { ... }
+
+    public void Insert(Rect bounds); // registra `bounds` en cada celda que cubre
+    public bool Overlaps(Rect candidate); // consulta solo las celdas de `candidate` y sus vecinas
+}
+```
+
+```csharp
+// Runtime/TrafficLaneOccupancy.cs (nuevo) — Ítem 8, etapa 3
+// Resuelve solo "¿hay un CarAgent inmediatamente delante en el mismo tramo?".
+// Todo lo demás (peatones, cruces, obstáculos arbitrarios) sigue por SphereCastNonAlloc.
+public sealed class TrafficLaneOccupancy : MonoBehaviour
+{
+    // Clave = arista dirigida (nodo origen, nodo destino) del grafo de TrafficNetwork.
+    // Valor = agentes en ese tramo, ordenados por DistanceTravelled.
+    private readonly Dictionary<(int from, int to), List<CarAgent>> segmentOccupants = new();
+
+    public void Enter(CarAgent agent, int fromNode, int toNode); // llamado por CarAgent al entrar en un tramo
+    public void Leave(CarAgent agent, int fromNode, int toNode); // llamado al salir/llegar
+    public bool TryGetCarAhead(CarAgent agent, out CarAgent ahead); // false ⇒ CarAgent recurre al SphereCast como hoy
+}
+
+// Runtime/TrafficNetwork.cs
+[SerializeField] private TrafficLaneOccupancy laneOccupancy; // mismo GameObject que Manager
+public TrafficLaneOccupancy LaneOccupancy => laneOccupancy;
+```
+
+```csharp
+// Runtime/PedestrianRoadProximityGrid.cs (nuevo) — Ítem 8, etapa 4
+// Rejilla espacial de peatones cercanos a la calzada, consultada por CarAgent en vez de
+// SphereCastNonAlloc cuando pedestrianCount > staggerMinAgentCount.
+public sealed class PedestrianRoadProximityGrid : MonoBehaviour
+{
+    private readonly Dictionary<(int x, int z), List<PedestrianAgent>> cells = new();
+
+    public void Rebuild(IReadOnlyList<PedestrianAgent> agents); // llamado una vez por frame por PedestrianManager
+    public void QueryNear(Vector3 position, float radius, List<PedestrianAgent> results);
+}
+
+// Runtime/PedestrianNetwork.cs
+[SerializeField] private PedestrianRoadProximityGrid roadProximity; // mismo GameObject que Manager
+public PedestrianRoadProximityGrid RoadProximity => roadProximity;
+```
+
+```csharp
+// Runtime/PedestrianNetwork.cs — Ítem 9
+// Componentes conexas: recalculadas en Build() junto a anillos/cruces/POI (flood fill sobre
+// las aristas ya construidas). Evita que PlanNewDestination pruebe candidatos inalcanzables.
+private int[] nodeComponent; // paralelo a `nodes`, tamaño = nodes.Count
+public int ComponentOf(int nodeIndex) => nodeComponent[nodeIndex];
+
+// Caché de árboles BFS por nodo origen, invalidada en cada Build(). Vida corta: pensada para
+// que varios peatones que planifican en la misma ventana de frames desde nodos cercanos no
+// repitan el mismo BFS, no como caché persistente entre sesiones.
+private readonly Dictionary<int, int[]> cameFromCache = new(); // origen -> árbol BFS (cameFrom)
+```
+
+```csharp
+// Runtime/PedestrianPathBufferPool.cs (nuevo) — Ítem 9
+// Hoy cada PedestrianAgent reserva su propio array del tamaño del grafo de por vida
+// (memoria O(peatones × nodos)). Como la planificación inicial pasa a repartirse entre
+// frames (esta misma sección), en un instante dado solo un subconjunto pequeño de agentes
+// está realmente planificando: un pool compartido, dimensionado al grafo, basta.
+internal sealed class PedestrianPathBufferPool
+{
+    private readonly int nodeCount;
+    private readonly Stack<int[]> visited = new();
+    private readonly Stack<int[]> cameFrom = new();
+
+    public PedestrianPathBufferPool(int nodeCount) { ... }
+    public (int[] visited, int[] cameFrom) Rent();
+    public void Return(int[] visited, int[] cameFrom);
+}
+
+// Runtime/PedestrianManager.cs
+[SerializeField] private PedestrianPathBufferPool pathBufferPool; // construido en OnEnable, sized a network.NodeCount
+```
+
+`PedestrianManager` también gana un campo de estado ligero (no serializado, no requiere struct propio) para escalonar la planificación inicial: un contador de frame por agente que difiere su primer `PlanNewDestination` en lugar de dispararlo todo en `Start`.
+
+## Plan de implementación
+
+1. **Añadir el paquete de Performance Testing y montar los proyectos de test.** Añadir `com.unity.test-framework.performance` al `manifest.json` del proyecto. Crear `Assets/Tests/EditMode/`, `Assets/Tests/PlayMode/` y `Assets/Tests/Performance/`, cada uno con su `.asmdef` referenciando los ensamblados `CityGenerator.Runtime`/`CityGenerator.Editor` y `UnityEngine.TestRunner`/`UnityEditor.TestRunner`. Verificación: el Test Runner de Unity (`Window > General > Test Runner`) detecta las tres carpetas vacías sin errores de compilación.
+
+2. **Tests EditMode (ítem 6, primera mitad).** Escribir los tests de `CityGeneratorGrid`, `CityGeneratorDistributionUtility`, `CityGeneratorValidator.ValidateDetailed` (incluidos los 7 casos de SPEC 04), pesos de ruta, `PedestrianNetwork.FindPath` (BFS) y persistencia de POI. Verificación: todos pasan en verde contra el código actual (son tests de regresión sobre comportamiento ya existente, no deben requerir cambios de producción).
+
+3. **Tests PlayMode (ítem 6, segunda mitad).** Escribir los tests de ciclo de semáforo, `CanCross`, registro/desregistro de agentes con reactivación, dos ciudades en la misma escena, y collider solo en un hijo. Verificación: todos pasan en verde contra el código actual.
+
+4. **Tests de generación con semilla fija (ítem 6, tercera parte).** Añadir los tests 1×3, 5×5 y 10×10 con `useCustomSeed` activo, comprobando ausencia de excepciones y los invariantes acordados (número de bloques, edificios colocados, nodos de red). Verificación: los tres pasan en verde.
+
+5. **Suite de Performance y medición baseline (ítem 6, cuarta parte).** Escribir los tests de `Assets/Tests/Performance/` (tiempo de generación por tamaño de rejilla, `GC Alloc`, coste de `SyncTransforms`, coste de los `Update` de los managers, memoria aproximada). Ejecutarlos contra 1×3/5×5/10×10 y registrar los números en la sección de resultados de este spec antes de tocar el ítem 7. Verificación: los tests corren y producen números reproducibles (mismo orden de magnitud en dos ejecuciones seguidas).
+
+6. **Índice espacial de colocación (ítem 7).** Implementar `CityGeneratorSpatialHash` e integrarlo en `CityGeneratorPlacementEngine` como índice auxiliar sobre `obstacles`. Verificación: los tests de generación con semilla fija (paso 4) siguen dando el mismo resultado exacto que antes del cambio (misma disposición de objetos, la única diferencia es el coste de la consulta); repetir la medición de tiempo de generación de 10×10 del paso 5 y anotar el delta.
+
+7. **Medición con tráfico/peatones cargados.** Generar una ciudad con 60/150/300 vehículos y peatones (tres corridas) y ejecutar la suite de Performance en runtime, registrando los números como baseline para los ítems 8-9. Verificación: los números quedan anotados en el spec/PR antes de continuar.
+
+8. **`SyncTransforms` condicional y movido al manager (ítem 8, etapas 1-2).** Modificar `TrafficNetwork`/`TrafficManager` según el modelo de datos. Verificación: los tests PlayMode de tráfico (paso 3) siguen en verde; una escena sin ningún `CarAgent` registrado deja de invocar `Physics.SyncTransforms()` (comprobable con un `Profiler.BeginSample` temporal o un contador de llamadas en el test).
+
+9. **Índice de ocupación por carril (ítem 8, etapa 3).** Implementar `TrafficLaneOccupancy`, conectarlo a `CarAgent.Enter`/`Leave` por tramo, y hacer que la comprobación de "coche delante" lo consulte antes de recurrir al `SphereCastNonAlloc`. Verificación: los tests de tráfico siguen en verde (comportamiento de frenado idéntico); repetir la medición de 150/300 vehículos del paso 7 y anotar el delta en coste de sensor.
+
+10. **Rejilla de proximidad peatonal para vehículos (ítem 8, etapa 4).** Implementar `PedestrianRoadProximityGrid`, poblarla desde `PedestrianManager` una vez por frame, y hacer que `CarAgent` la consulte para el sensor de peatones cuando `pedestrianCount > staggerMinAgentCount`. Verificación: los tests de frenado ante peatón siguen en verde; repetir la medición con 300 peatones y anotar el delta.
+
+11. **Componentes conexas y filtrado de destinos (ítem 9, primera parte).** Añadir `nodeComponent` a `PedestrianNetwork`, recalculado en `Build()`, y filtrar `PlanNewDestination` por componente conexa antes de intentar rutas. Verificación: el test EditMode de BFS (paso 2) sigue en verde; en una rejilla con `gridWidth == 1` (ring aislado por bloque, ver CLAUDE.md) los peatones dejan de intentar candidatos inalcanzables — comprobable contando llamadas a `FindPath` que fallan por "sin ruta" antes/después.
+
+12. **Reparto de planificación inicial entre frames (ítem 9, segunda parte).** `PedestrianManager` escalona el primer `PlanNewDestination` de cada agente en vez de dispararlos todos en `Start`. Verificación: repetir la medición de "pico al entrar en Play" con 300 peatones (`GC Alloc`/tiempo del primer frame tras `Awake`) y anotar el delta frente al paso 7.
+
+13. **Caché de rutas BFS y pool de buffers (ítem 9, tercera y cuarta parte).** Añadir `cameFromCache` a `PedestrianNetwork` y `PedestrianPathBufferPool` a `PedestrianManager`; `PedestrianAgent.PlanNewDestination` pasa a pedir sus buffers al pool en vez de mantener uno propio permanente. Verificación: los tests EditMode/PlayMode de pathfinding siguen en verde; medir memoria total con 300 peatones y compararla contra el baseline O(peatones × nodos) del paso 7.
+
+14. **Deduplicar pares y escalonar separación (ítem 9, quinta parte).** `PedestrianManager` procesa cada pareja de agentes cercanos una sola vez y reduce la frecuencia de recálculo para agentes lejos de cámara, siguiendo el mismo patrón de staggering ya usado para sensores. Verificación: comportamiento de separación visualmente idéntico (los peatones no se atraviesan); medir coste de `PedestrianManager.Update` con 300 peatones y anotar el delta.
+
+15. **Medición final y cierre.** Repetir la suite de Performance completa (generación 1×3/5×5/10×10, runtime con 60/150/300 agentes) y volcar la comparación completa antes/después en el spec o en la descripción del PR.
+
+## Criterios de aceptación
+
+- [x] Las carpetas `Assets/Tests/EditMode/`, `Assets/Tests/PlayMode/` y `Assets/Tests/Performance/` existen, compilan y aparecen en el Test Runner de Unity.
+- [x] Todos los tests EditMode del paso 2 (grid, distribución de porcentajes, validación completa, pesos de ruta, BFS, persistencia de POI) pasan en verde.
+- [x] Todos los tests PlayMode del paso 3 (ciclo de semáforo, `CanCross`, registro/desregistro con reactivación, dos ciudades en la misma escena, collider solo en un hijo) pasan en verde.
+- [x] Los tests de generación con semilla fija (1×3, 5×5, 10×10) pasan en verde tanto antes como después de introducir el índice espacial (ítem 7), produciendo exactamente la misma disposición de objetos en ambos casos.
+- [x] La suite de Performance se ejecuta sin errores en los tres tamaños de rejilla y en las tres cargas de agentes (60/150/300), y sus números quedan registrados (baseline y post-cambio) en el spec o en la descripción del PR — sin exigir un umbral numérico fijo como condición de aceptación.
+- [x] `CityGeneratorPlacementEngine` usa `CityGeneratorSpatialHash` para las comprobaciones de solapamiento; el comportamiento observable de colocación (qué queda colocado y dónde, dada una semilla) no cambia.
+- [x] Una escena sin ningún `CarAgent` registrado no invoca `Physics.SyncTransforms()`.
+- [x] `TrafficLaneOccupancy` resuelve correctamente el caso "coche delante en el mismo tramo" sin `SphereCast`; el frenado ante peatones y en cruces sigue funcionando exactamente igual que antes (verificado por los tests PlayMode de tráfico).
+- [x] `PedestrianRoadProximityGrid` permite que los vehículos sigan frenando ante peatones cercanos a la calzada cuando `pedestrianCount > staggerMinAgentCount`, sin usar `SphereCast` para ese caso.
+- [x] En una rejilla con `gridWidth == 1` o `gridHeight == 1` (rings aislados por bloque), los peatones ya no intentan planificar rutas hacia nodos de otra componente conexa inalcanzable.
+- [x] La planificación inicial de destino de los peatones se reparte en varios frames tras el spawn, en vez de concentrarse toda en el primer frame de `Start`.
+- [x] `PedestrianAgent` deja de reservar un array del tamaño del grafo por agente de forma permanente; los buffers de BFS se obtienen de `PedestrianPathBufferPool`.
+- [x] La pasada de separación de `PedestrianManager` procesa cada pareja de agentes cercanos una sola vez, y el comportamiento visual de separación (los peatones no se atraviesan entre sí) no cambia.
+- [x] El proyecto compila sin warnings nuevos y una generación completa (rejilla 5×5 con tráfico y peatones activados) sigue completándose sin excepciones tras aplicar todos los cambios de este spec.
+- [x] La comparación final de mediciones (antes/después, paso 15) queda documentada.
+
+## Decisiones tomadas y descartadas
+
+- **Tests fuera del package, en `Assets/Tests/`.** Se descarta meterlos dentro de `Packages/com.santiandrade.citygenerator/Tests/` (la convención estándar de Unity) porque, igual que `CityGeneratorReleaseWindow.cs`/`CityGeneratorSetDefaultsWindow.cs`, son herramientas de desarrollo de este repo, no parte del package distribuible; un usuario que instala el package por git URL no necesita ni espera esta suite.
+- **`com.unity.test-framework.performance` sí como dependencia, pero del proyecto, no del package.** Se añade al `manifest.json` de este proyecto porque los tests viven fuera del package; `Packages/com.santiandrade.citygenerator/package.json` no gana ninguna dependencia nueva por este spec.
+- **Umbrales de rendimiento informativos, no bloqueantes.** Se descarta fijar ahora números concretos (p. ej. "10×10 en <X ms") porque el propio informe técnico advierte que sus estimaciones de ganancia son arquitectónicas, sin profiling real previo — fijar un umbral sin datos de referencia sería inventar un número. Los benchmarks se ejecutan y se registran; la aceptación depende de que las mediciones existan y de que el comportamiento funcional no haya cambiado, no de superar una cifra.
+- **Ítem 8 completo (las 4 etapas), no solo la etapa barata.** Se descarta parar en el `SyncTransforms` condicional (etapa 1, la única de coste S) porque el propio informe encuadra las 4 etapas como un único ítem progresivo, y este spec ya sigue el orden "medir primero" con una medición intermedia entre la etapa 1-2 y la 3-4, lo que permite decidir con datos si merece la pena seguir sin necesitar un spec adicional solo para eso.
+- **Índice de ocupación por carril (ítem 8, etapa 3): sustituye solo el sensor de "coche delante", no el de peatones.** Se descarta que la misma estructura resuelva también la detección de peatones porque son problemas de forma distinta (ocupación discreta por tramo vs. proximidad continua en el plano); mezclarlos habría acoplado dos optimizaciones independientes y aumentado el riesgo de romper el frenado ante peatones, que es una de las cuatro reglas "load-bearing" de `CarAgent` documentadas en CLAUDE.md.
+- **Ítem 9 completo (todas las propuestas), no solo el subconjunto barato.** Se descarta dejar fuera la reutilización de árboles BFS y el pooling de buffers porque comparten el mismo mecanismo que las otras dos mejoras (siempre tocando `PlanNewDestination`/`PedestrianNetwork.Build()`) y dividirlas habría sido trabajo redundante entre dos specs, igual que se decidió para el ítem 10 en SPEC 04.
+- **Pool de buffers compartido en vez de un array por agente.** Se descarta que cada `PedestrianAgent` siga reservando su propio array de tamaño del grafo (aunque ya sea zero-allocation por llamada) porque el coste real señalado por el informe es de memoria total O(peatones × nodos), no de GC por frame; un pool dimensionado al grafo y prestado durante la ventana de planificación (ahora repartida en frames, paso 12) ataca directamente ese número sin cambiar la naturaleza zero-allocation del BFS.
+- **Caché de rutas BFS con vida corta (invalidada en cada `Build()`), no persistente entre sesiones.** Se descarta serializarla o mantenerla más allá de un `Build()` porque el grafo puede cambiar (rebuild manual, reinserción de POI); una caché que sobreviviera a un `Build()` correría el riesgo de devolver rutas obsoletas.
+- **Índice espacial de colocación (ítem 7) como estructura auxiliar sobre `obstacles`, no como reemplazo de la lista.** Seguridad ante desincronización: si `CityGeneratorSpatialHash` y `obstacles` divergieran, sería un bug sutil de generación. Mantener `obstacles` como fuente de verdad y el hash como índice deriva de ella minimiza superficie de error, siguiendo el mismo principio ya aplicado en `CityGeneratorGridPreview` (SPEC 04: "la imagen y la escena generada nunca pueden discrepar").
+- **Sin umbral de tamaño de rejilla nuevo.** Se descarta subir o quitar el límite de 10×10 de la UI como parte de este spec: el índice espacial mejora el coste asintótico, pero decidir si el límite debe cambiar es una decisión de producto que depende de las mediciones del paso 15, no algo a fijar de antemano.
+- **Sin cambios en `CarAgent`/`PedestrianAgent` fuera de lo descrito.** Las cuatro reglas "load-bearing" de `CarAgent` documentadas en CLAUDE.md (identidad por referencia en el sensor, reserva de prioridad en cruces sin semáforo, etc.) y el comportamiento de `PedestrianAgent` (sin mecánica de atasco propia) se mantienen intactos; este spec optimiza cómo se obtienen los datos que alimentan esas reglas, no las reglas mismas.
+
+No se identifican riesgos adicionales que requieran una sección propia más allá de lo ya cubierto en Scope/Decisiones.
+
+## Resultados de medición
+
+Máquina de referencia: Intel Core Ultra 9 285H, RTX 5060 Laptop GPU, 32 GB RAM, Windows 11, Unity 6000.5.8f1, Editor en modo Development, `com.unity.test-framework.performance@3.5.0`.
+
+### Baseline previo al ítem 7 (paso 5) — generación, semilla fija, `Measure.Method` (5 muestras, 1 warmup) + `GC()`
+
+| Rejilla | Tiempo medio (ms) | Min / Max (ms) | GC Alloc por ejecución (bytes) |
+|---|---|---|---|
+| 1×3 | 62.13 | 57.40 / 67.99 | 6 057 |
+| 5×5 | 258.84 | 248.36 / 272.70 | 18 723 |
+| 10×10 | 1 458.39 | 1 400.19 / 1 493.08 | 68 008 |
+
+Memoria managed aproximada de una ciudad 5×5 generada (`GC.GetTotalMemory` antes/después, con colección forzada antes de medir): **≈0.223 MB** de delta neto — nota: esto mide solo el crecimiento del heap managed inmediatamente after `Assemble`; no incluye memoria nativa (mallas, texturas, materiales) de los GameObjects instanciados, que es donde vive la mayor parte del coste real de una ciudad generada.
+
+### Baseline previo a los ítems 8-9 (paso 7) — runtime con tráfico y peatones activos, rejilla 10×10, `Measure.Frames` (60 muestras, 10 warmup)
+
+| Agentes (vehículos + peatones) | Frame time medio (ms) | Min / Max (ms) |
+|---|---|---|
+| 60 + 60 | 4.94 | 4.21 / 7.73 |
+| 150 + 150 | 7.30 | 6.62 / 8.50 |
+| 300 + 300 | 11.61 | 10.64 / 12.91 |
+
+Esta medición es el coste de frame combinado (`TrafficManager.Update` + `PedestrianManager.Update` + `Physics.SyncTransforms` + el resto del frame de Test Runner en Play Mode), no aislado por subsistema: la base de código no tiene `ProfilerMarker`s propios en estos métodos, y añadir instrumentación solo para medir queda fuera del alcance de este spec (ver "Sin cambios en `CarAgent`/`PedestrianAgent` fuera de lo descrito"). Sirve como número de referencia informativo para comparar el antes/después de los ítems 8-9, no como medición aislada de cada optimización.
+
+### Después del ítem 7 — índice espacial de solapamiento (paso 6)
+
+| Rejilla | Tiempo medio antes (ms) | Tiempo medio después (ms) | Delta |
+|---|---|---|---|
+| 10×10 | 1 458.39 | 1 189.37 | **-18.4%** |
+
+GC Alloc por ejecución (10×10): 68 008 → 68 660 bytes (+652 B, despreciable — las listas del hash espacial). Los tests de generación con semilla fija (`SeededGenerationTests`) siguen en verde después del cambio, incluyendo `Assemble_SameSeed_ProducesIdenticalBuildingLayout`: la disposición generada es exactamente la misma, solo cambia el coste de la comprobación de solapamiento.
+
+### Después del ítem 8 — coste físico del tráfico, las 4 etapas (pasos 8-10)
+
+Cambios: `Physics.SyncTransforms()` movido de `TrafficNetwork.LateUpdate` a `TrafficManager.Update` (solo si `agents.Count > 0`); `TrafficLaneOccupancy` resuelve el caso "coche delante en el mismo carril" sin `SphereCast`; `PedestrianRoadProximityGrid` permite a `CarAgent` consultar peatones cercanos sin `SphereCast` una vez hay más peatones que `staggerMinAgentCount`.
+
+| Agentes (vehículos + peatones) | Frame time medio antes (ms) | Frame time medio después (ms) | Delta |
+|---|---|---|---|
+| 60 + 60 | 4.94 | 5.20 | +5% (ruido; staggering aún no activo con 60 = staggerMinAgentCount) |
+| 150 + 150 | 7.30 | 7.48 | +2% (dentro del ruido de medición del Editor) |
+| 300 + 300 | 11.61 | 11.23 | **-3.3%** |
+
+La ganancia medida es modesta a esta escala: el coste dominante en el Editor a estos tamaños de agentes es el propio overhead del Test Runner/Editor por frame, no el sensor de `CarAgent` en sí — la ganancia real de evitar `SphereCastNonAlloc` debería notarse más en un build standalone o con recuentos de agentes bastante mayores. Todos los tests PlayMode de tráfico/peatones (ciclo de semáforo, `CanCross`, registro/desregistro) siguen en verde; los tests de generación con semilla fija siguen dando exactamente el mismo resultado (los cambios del ítem 8 no tocan la colocación, solo el runtime).
+
+### Después del ítem 9 — pathfinding y separación peatonal, todas las propuestas (pasos 11-14)
+
+Cambios: componentes conexas (`PedestrianNetwork.ComponentOf`) filtran `PlanNewDestination` antes de intentar una ruta; la planificación inicial de cada peatón se reparte en varios segundos según su orden de spawn en vez de dispararse toda en el primer frame; `FindPath` cachea el árbol BFS completo por nodo origen (`cameFromCache`, invalidado en cada `Build()`/registro de POI) en vez de recalcularlo por cada uno de los hasta 8 candidatos que prueba `PlanNewDestination`; `PedestrianAgent` ya no reserva un array del tamaño del grafo de por vida, sino que pide un buffer a `PedestrianManager.PathBufferPool` solo durante la planificación; `PedestrianManager.ApplyLocalSeparation` procesa cada pareja de agentes cercanos una sola vez (antes se procesaba dos veces, una por cada lado) y omite una pareja por completo cuando ninguno de los dos agentes está "activo" ese frame según el mismo staggering ya usado para el sensor.
+
+| Agentes (vehículos + peatones) | Frame time medio después del ítem 8 (ms) | Frame time medio después del ítem 9 (ms) | Delta |
+|---|---|---|---|
+| 60 + 60 | 5.20 | 5.31 | +2% (ruido) |
+| 150 + 150 | 7.48 | 7.02 | **-6.1%** |
+| 300 + 300 | 11.23 | 10.80 | **-3.8%** |
+
+Un bug real se detectó y corrigió gracias a esta propia suite de Performance: al añadir componentes conexas, cada punto de interés de plaza registrado tras `Build()` (`RegisterPointOfInterest`, llamado por `CityGeneratorPedestrianBuilder.RegisterPointsOfInterest`) hacía crecer la lista de nodos sin mantener sincronizado el array de componentes, lanzando `IndexOutOfRangeException` la primera vez que un peatón intentaba planificar destino — `PerFrameCost_150Agents`/`_300Agents`/`_60Agents` fallaron con esa excepción en la primera ejecución tras implementar el ítem 9, y siguen en la suite como regresión (`RegisterPointOfInterest_RepeatedlyAfterBuild_DoesNotThrow`, `PedestrianNetworkTests`).
+
+El pico de memoria O(peatones × nodos) al entrar en Play y el efecto exacto del reparto de la planificación inicial entre frames no se miden directamente en esta suite (requerirían capturar el primer frame tras `Awake` en aislamiento, fuera del alcance práctico de `Measure.Frames`); su corrección se verifica arquitectónicamente (el campo `path` de `PedestrianAgent` ya no se dimensiona a `network.NodeCount` en `Start()`, ver el código) en vez de con un número.
+
+### Comparación final (paso 15)
+
+| Medición | Baseline (paso 5/7) | Final (tras ítems 7-9) | Delta total |
+|---|---|---|---|
+| Generación 1×3 (tiempo medio) | 62.13 ms | 67.17 ms | +8% (ruido del Editor a esta escala; ítem 7 no aporta en rejillas casi sin obstáculos) |
+| Generación 5×5 (tiempo medio) | 258.84 ms | 250.74 ms | -3.1% |
+| Generación 10×10 (tiempo medio) | 1 458.39 ms | 1 206.82 ms | **-17.2%** |
+| Runtime 60+60 agentes (frame medio) | 4.94 ms | 5.31 ms | +7.5% (ruido; por debajo de `staggerMinAgentCount`, el staggering nunca se activa a este tamaño) |
+| Runtime 150+150 agentes (frame medio) | 7.30 ms | 7.02 ms | -3.8% |
+| Runtime 300+300 agentes (frame medio) | 11.61 ms | 10.80 ms | **-7.0%** |
+
+Todos los tests EditMode/PlayMode/Performance del spec están en verde tras aplicar los ítems 7-9; los tests de generación con semilla fija confirman que la disposición generada no cambió. La ganancia es clara y creciente con el tamaño de la rejilla/número de agentes (que es exactamente donde el informe técnico predijo el problema O(n²)); a los tamaños pequeños (1×3, 60 agentes) el ruido del Editor domina sobre la ganancia real, como cabía esperar de optimizaciones cuyo coste evitado crece con n.


### PR DESCRIPTION
## Summary
- Adds the missing EditMode/PlayMode/Performance test suite (`Assets/Tests/`, outside the package): 56 EditMode + 14 PlayMode + 7 Performance tests, all green.
- Implements items 7-9 from the technical review that SPEC 04 deferred to this round:
  - **Item 7** — `CityGeneratorSpatialHash` indexes the shared obstacles list so `CityGeneratorPlacementEngine`'s overlap check no longer scans it linearly per candidate (10x10 generation: -17.2%).
  - **Item 8** (4 stages) — `Physics.SyncTransforms` moves from `TrafficNetwork` to `TrafficManager.Update`, only called when at least one `CarAgent` is registered; `TrafficLaneOccupancy` resolves "car ahead in the same lane segment" without a `SphereCast`; `PedestrianRoadProximityGrid` lets `CarAgent` query nearby pedestrians the same way once the pedestrian count justifies it.
  - **Item 9** (all 5 proposals) — connected components so `PlanNewDestination` never attempts an unreachable route; staggered initial destination planning by spawn index; cached BFS tree per origin instead of recomputing per candidate destination; shared `PedestrianPathBufferPool` instead of a permanent per-agent array sized to the whole graph; deduplicated + staggered local-separation pass.
- Baseline/delta measurements are recorded in `specs/05-performance-and-tests.md`.
- **Post-implementation fix**: `PedestrianRoadProximityGrid` only indexed registered `PedestrianAgent`s, so once it took over from `CarAgent`'s `SphereCast` sensor (pedestrian count > `staggerMinAgentCount`), the player — on the same layer but never a `PedestrianAgent` — became invisible to vehicles and cars stopped braking for it entirely. Fixed by tracking the player's position separately in the grid and checking it explicitly in `CarAgent`, with 3 regression tests reproducing the exact scenario.

## Test plan
- [x] `Assets/Tests/EditMode` — 56/56 passing (grid, distribution, validator, route weights, pedestrian network BFS/components, seeded generation determinism)
- [x] `Assets/Tests/PlayMode` — 14/14 passing (traffic light cycle, `CanCross`, manager registration/reactivation, two independent cities, collider-on-child detection, player-detection regression)
- [x] `Assets/Tests/Performance` — 7/7 passing, numbers recorded in `specs/05-performance-and-tests.md`
- [x] Generation with a fixed seed produces the exact same layout before/after item 7
- [x] Manual verification that the player-detection fix resolves the reported issue (cars braking for the player again once pedestrian count exceeds the stagger threshold)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01BreLNyTtaFHEW8t78uxryU