### PR TITLE
docs: make README introductions easier to scan

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -4,28 +4,30 @@
 
 <img src="Packages/com.santiandrade.citygenerator/Editor/ToolThumbnail.png" alt="Miniatura de City Generator" width="100%">
 
-Una herramienta de Editor para Unity que genera proceduralmente una ciudad —
-carreteras, aceras, marcas viales, edificios, plazas, mobiliario urbano, semáforos,
-tráfico autónomo, peatones, un ciclo día/noche opcional y un HUD de minimapa— en una
-escena nueva o existente.
-Ábrela desde **Tools > City Generator > Open**.
+Una herramienta de Editor para Unity que genera proceduralmente una ciudad en una
+escena nueva o existente. Ábrela desde **Tools > City Generator > Open**.
 
-La ventana está dividida en cuatro pestañas: **City** (cuadrícula, suelo, edificios,
-plazas, vehículos, mobiliario, un Day/Night Cycle opcional para la luz direccional
-generada —hora de inicio, multiplicador de velocidad y un gradiente de color/curva de
-intensidad a lo largo de las 24 h— y Custom Places: lugares colocados a mano con un
-título, un prefab, una manzana/esquina elegida en un grid visual, una orientación fija
-y un flag opcional "Is Point Of Interest" que marca la entrada en el minimapa, y que se
-instancian en lugar de un edificio aleatorio en esa posición), **Player** (Player
-Prefab, movimiento, ajuste del `CharacterController` y de la cámara), **Pedestrians**
-(la lista de prefabs de peatones, además de su comportamiento al caminar/esperar y el
-ajuste de la multitud), y **Minimap** (activado por defecto; resolución de textura y
-radio de visión del HUD de minimapa en el juego) — todo se edita desde la ventana, sin
-necesidad de tocar el código del paquete.
-
-Se distribuye como el package embebido `com.santiandrade.citygenerator`, instalable
-directamente desde una git URL, con un conjunto completo de prefabs de demostración
-incluido para que la ventana esté lista para generar una ciudad nada más instalarlo.
+- **Genera una ciudad completa:** carreteras, aceras, marcas viales, edificios, plazas,
+  mobiliario urbano, semáforos, tráfico autónomo, peatones, un ciclo día/noche opcional
+  y un HUD de minimapa.
+- **Configura todo desde la ventana:**
+  - **City:** cuadrícula, suelo, edificios, plazas, vehículos, mobiliario, un Day/Night
+    Cycle opcional para la luz direccional generada (hora de inicio, multiplicador de
+    velocidad y un gradiente de color/curva de intensidad a lo largo de las 24 h) y
+    Custom Places.
+  - **Custom Places:** lugares colocados a mano con título, prefab, una
+    manzana/esquina elegida en un grid visual, orientación fija y un flag opcional
+    "Is Point Of Interest" que marca la entrada en el minimapa. Se instancian en lugar
+    de un edificio aleatorio en esa posición.
+  - **Player:** Player Prefab, movimiento y ajuste del `CharacterController` y la cámara.
+  - **Pedestrians:** la lista de prefabs de peatones, su comportamiento al
+    caminar/esperar y el ajuste de la multitud.
+  - **Minimap:** activado por defecto, con controles para la resolución de textura y el
+    radio de visión del HUD de minimapa en el juego.
+- **Instálala y genera de inmediato:** se distribuye como el package embebido
+  `com.santiandrade.citygenerator`, instalable directamente desde una git URL, con un
+  conjunto completo de prefabs de demostración incluido. No hace falta tocar el código
+  del package.
 
 ## Instalación
 

--- a/README.md
+++ b/README.md
@@ -4,26 +4,27 @@
 
 <img src="Packages/com.santiandrade.citygenerator/Editor/ToolThumbnail.png" alt="City Generator thumbnail" width="100%">
 
-An Editor tool for Unity that procedurally generates a city — roads, sidewalks, road
-markings, buildings, plazas, street furniture, traffic lights, autonomous traffic,
-pedestrians, an optional day/night cycle and a minimap HUD — into a new or existing
-scene. Open it from
-**Tools > City Generator > Open**.
+An Editor tool for Unity that procedurally generates a city in a new or existing
+scene. Open it from **Tools > City Generator > Open**.
 
-The window is split into four tabs: **City** (grid, ground, buildings, plazas, vehicles,
-props, an optional Day/Night Cycle for the generated directional light — start hour, speed
-multiplier, and a colour gradient/intensity curve over the 24 h — and Custom Places:
-manually-placed entries with a title, a prefab, a block/corner picked from a grid preview,
-a fixed orientation, and an optional "Is Point Of Interest" flag that surfaces the entry on
-the minimap, instantiated instead of a random building at that spot), **Player** (Player Prefab, movement, `CharacterController` and camera tuning),
-**Pedestrians** (the pedestrian prefab list, plus their walk/idle behaviour and crowd
-tuning), and **Minimap** (on by default; texture resolution and view radius for the
-in-game minimap HUD) — everything is editable from the window, nothing requires touching
-the package's code.
-
-It ships as the embedded package `com.santiandrade.citygenerator`, installable directly
-from a git URL, with a full set of demo prefabs included so the window is ready to
-generate a city the moment you install it.
+- **Generate a complete city:** roads, sidewalks, road markings, buildings, plazas,
+  street furniture, traffic lights, autonomous traffic, pedestrians, an optional
+  day/night cycle, and a minimap HUD.
+- **Configure everything from the window:**
+  - **City:** grid, ground, buildings, plazas, vehicles, props, an optional Day/Night
+    Cycle for the generated directional light (start hour, speed multiplier, and a
+    colour gradient/intensity curve over the 24 h), and Custom Places.
+  - **Custom Places:** manually placed entries with a title, prefab, block/corner picked
+    from a grid preview, fixed orientation, and an optional "Is Point Of Interest" flag
+    that surfaces the entry on the minimap. They are instantiated instead of a random
+    building at that spot.
+  - **Player:** Player Prefab, movement, `CharacterController`, and camera tuning.
+  - **Pedestrians:** the pedestrian prefab list, walk/idle behaviour, and crowd tuning.
+  - **Minimap:** enabled by default, with texture resolution and view radius controls for
+    the in-game HUD.
+- **Install and generate immediately:** it ships as the embedded package
+  `com.santiandrade.citygenerator`, installable directly from a git URL, with a complete
+  set of demo prefabs included. No package code needs to be touched.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Rework the introduction before Installation in `README.md` into scannable feature bullets.
- Mirror the same structure and content in `README.es.md`.
- Preserve the installation and all subsequent documentation unchanged.

## Verification
- `git diff --check`